### PR TITLE
docs(agents): add Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,3 +297,14 @@ Project rules for **user projects** (not this repo’s own guide) are documented
 | Scrollback / tool card UI | `xai-grok-pager/src/scrollback/blocks/` |
 | Prompt / system instructions | `xai-grok-agent` templates + `prompt/` |
 | Auto-update | `xai-grok-update` + `OPEN_GROK_VERSION` |
+
+---
+
+## 11. Cursor Cloud specific instructions
+
+Durable, non-obvious notes for agents in the Cloud VM (the update script already ran `cargo fetch --locked`). Standard build/test/run commands live in §5–§6 and the [`develop-open-grok`](.agents/skills/develop-open-grok/SKILL.md) skill — use those; only the caveats below are cloud-specific.
+
+- **`protoc` is a hard build dependency.** `xai-grok-tools-api`'s `build.rs` compiles protos, and `xai-proto-build::find_protoc` resolves `protoc` from `$PROTOC` → `bin/protoc` (dotslash) → `PATH`. The VM snapshot has both a system `protoc` (`apt install protobuf-compiler`, satisfies the `PATH` fallback) and `dotslash` on `PATH` (so `./bin/protoc` and `./bin/setup-dev` work). If a build fails with a protoc/prost error, install one of those — it is not a code issue.
+- **First compile is long, not hung.** A cold `cargo check -p xai-grok-pager-bin` is ~3–4 min and a cold `cargo build --bin open-grok` is ~5 min on this VM. Prefer package-scoped `-p <crate>` checks; inspect process activity before assuming a hang.
+- **Running the app end-to-end needs provider auth.** `target/debug/open-grok` / `./bin/open-grok-dev` launch the TUI (account chooser: ChatGPT Codex / xAI Grok). A real agent turn requires credentials — set `XAI_API_KEY` or run `open-grok login`. Without creds, only CLI smokes work: `--version`, `models`, `completions <shell>`, and `inspect` (config/skills discovery). A headless turn is `./bin/open-grok-dev -p "say hi"`.
+- **Always use an isolated `OPENGROK_HOME`** (e.g. `export OPENGROK_HOME=/tmp/opengrok-test`) for runtime/tests so real user state under `~/.opengrok` is never touched.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the Open Grok Rust workspace and records durable, non-obvious startup caveats for future cloud agents.

This PR only adds a `## Cursor Cloud specific instructions` section to `AGENTS.md`. No product code is changed. The environment itself (system `protoc`, `dotslash`, cargo dependency cache) is provisioned via the VM snapshot + update script.

## Environment verified

- **Toolchain:** Rust `1.92.0` (pinned by `rust-toolchain.toml`), already present.
- **Build deps installed:** system `protoc` (`apt protobuf-compiler`, PATH fallback for `xai-proto-build`) and `dotslash 0.5.6` (provides pinned `bin/protoc` 29.3 so `./bin/setup-dev` works).
- **Update script:** `cargo fetch --locked` (minimal dependency refresh).

## Checks run

| Step | Command | Result |
| --- | --- | --- |
| Setup / check | `./bin/setup-dev` (`cargo fetch` + `cargo check -p xai-grok-pager-bin`) | pass |
| Build | `cargo build --locked -p xai-grok-pager-bin --bin open-grok` | pass |
| Lint (fmt) | `cargo fmt --all -- --check` | pass |
| Lint (clippy) | `cargo clippy --locked -p xai-grok-config --all-targets` | clean |
| Tests | `cargo test --locked -p xai-grok-config` | 136 passed, 0 failed |
| Run smoke | `./bin/open-grok-dev --version`, `open-grok inspect`, `completions`, TUI launch | pass |

## Hello-world (end-to-end)

Launched the interactive `open-grok` TUI on the desktop — it renders the account chooser (ChatGPT Codex / xAI Grok), message input, and version footer, then exits cleanly on `q`.

[open_grok_tui_launch.mp4](https://cursor.com/agents/bc-ed698d54-367a-4887-bbe6-d8bb8ef781fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopen_grok_tui_launch.mp4)

[Open Grok TUI rendered](https://cursor.com/agents/bc-ed698d54-367a-4887-bbe6-d8bb8ef781fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopen_grok_tui_rendered.webp)

A live agent turn (sending a prompt and getting a model response) additionally requires provider credentials (`XAI_API_KEY` or `open-grok login`), which are not present in this environment.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed698d54-367a-4887-bbe6-d8bb8ef781fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed698d54-367a-4887-bbe6-d8bb8ef781fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

