### PR TITLE
Configure Hawk public API analysis

### DIFF
--- a/bin/hawk-check
+++ b/bin/hawk-check
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+hawk_toolchain="${HAWK_RUST_TOOLCHAIN:-1.97.1}"
+
+if ! command -v rustup >/dev/null 2>&1; then
+    echo "error: required command 'rustup' is not installed" >&2
+    exit 1
+fi
+
+if ! rustup run "$hawk_toolchain" rustc --version >/dev/null 2>&1; then
+    echo "error: Hawk requires Rust $hawk_toolchain" >&2
+    echo "install it with: rustup toolchain install $hawk_toolchain" >&2
+    exit 1
+fi
+
+if ! command -v cargo-hawk >/dev/null 2>&1; then
+    echo "error: required command 'cargo-hawk' is not installed" >&2
+    echo "install cargo-hawk 0.1.9 from: https://github.com/astral-sh/hawk/releases/tag/0.1.9" >&2
+    exit 1
+fi
+
+cd "$repo_root"
+exec cargo +"$hawk_toolchain" hawk check --manifest-path "$repo_root/Cargo.toml" "$@"

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -7,6 +7,7 @@ Also see: root [`README.md`](../../README.md), [`CONTRIBUTING.md`](../../CONTRIB
 ## Prerequisites
 
 - Rust pin: `rust-toolchain.toml` (currently **1.92.0** + rustfmt, clippy)
+- Optional Hawk analysis: `cargo-hawk` **0.1.9** + Rust **1.97.1**
 - `protoc` via `./bin/protoc` (Dotslash) or `PROTOC` / `PATH`
 - Xcode CLT for signed macOS release artifacts (Apple Silicon release path)
 
@@ -50,6 +51,32 @@ cargo clippy --locked --workspace --all-targets
 ```
 
 Workspace clippy config: `clippy.toml`. Format: `rustfmt.toml`.
+
+### Hawk public-API analysis
+
+[Hawk](https://github.com/astral-sh/hawk) checks whether public Rust APIs are
+needed by the shipped `open-grok` binary. It is experimental and tied to the
+compiler version used to build it, so its Rust 1.97.1 toolchain is kept
+separate from the workspace's pinned Rust 1.92.0 toolchain.
+
+Install the compatible toolchain and Hawk release:
+
+```sh
+rustup toolchain install 1.97.1
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/astral-sh/hawk/releases/download/0.1.9/cargo-hawk-installer.sh | sh
+```
+
+Run the workspace configuration in warning-only mode:
+
+```sh
+./bin/hawk-check
+```
+
+Use `./bin/hawk-check -D warnings` to enforce all default Hawk findings,
+`./bin/hawk-check --only dead-public` to focus on deletion candidates, or
+`./bin/hawk-check --fix` to apply machine-applicable visibility reductions.
+Review fixes before committing; dead declarations remain report-only.
 
 ## Testing strategy
 

--- a/docs/agents/development.md
+++ b/docs/agents/development.md
@@ -57,7 +57,9 @@ Workspace clippy config: `clippy.toml`. Format: `rustfmt.toml`.
 [Hawk](https://github.com/astral-sh/hawk) checks whether public Rust APIs are
 needed by the shipped `open-grok` binary. It is experimental and tied to the
 compiler version used to build it, so its Rust 1.97.1 toolchain is kept
-separate from the workspace's pinned Rust 1.92.0 toolchain.
+separate from the workspace's pinned Rust 1.92.0 toolchain. `hawk.toml`
+analyzes the default features plus the shipped `release-dist` feature rather
+than Cargo's unsupported synthetic `--all-features` combination.
 
 Install the compatible toolchain and Hawk release:
 
@@ -73,8 +75,7 @@ Run the workspace configuration in warning-only mode:
 ./bin/hawk-check
 ```
 
-Use `./bin/hawk-check -D warnings` to enforce all default Hawk findings,
-`./bin/hawk-check --only dead-public` to focus on deletion candidates, or
+Use `./bin/hawk-check -D warnings` to enforce all default Hawk findings or
 `./bin/hawk-check --fix` to apply machine-applicable visibility reductions.
 Review fixes before committing; dead declarations remain report-only.
 

--- a/hawk.toml
+++ b/hawk.toml
@@ -2,3 +2,7 @@
 package = "xai-grok-pager-bin"
 bin = "open-grok"
 reason = "public Open Grok binary shipped from this workspace"
+
+[[feature-profile]]
+name = "release-dist"
+features = ["xai-grok-pager-bin/release-dist"]

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,0 +1,4 @@
+[[production]]
+package = "xai-grok-pager-bin"
+bin = "open-grok"
+reason = "public Open Grok binary shipped from this workspace"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- declare the shipped `open-grok` binary as Hawk's production target
- analyze default features plus the actual `release-dist` feature instead of the workspace's unsupported synthetic all-feature combination
- add a repo-local runner that isolates Hawk's Rust 1.97.1 compiler from the workspace toolchain
- document installation, warning-only analysis, enforcement, and fixes

## Verification
- `bash -n bin/hawk-check`
- `cargo hawk --version` → 0.1.9
- `rustc +1.97.1 --version` → 1.97.1
- `./bin/hawk-check --color never` → success, 9,116 existing warning-level findings
  - 7,940 `hawk::unnecessary_public`
  - 699 `hawk::dead_public`
  - 477 `hawk::unnecessary_restricted_visibility`

The initial findings remain warning-only; this change does not apply a broad automatic visibility rewrite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8a1b-7a02-7a61-86e9-6517460246d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8a1b-7a02-7a61-86e9-6517460246d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

