### PR TITLE
Continue Hawk cleanup after restoring pager test API

### DIFF
--- a/crates/codegen/xai-grok-pager/src/acp/tracker.rs
+++ b/crates/codegen/xai-grok-pager/src/acp/tracker.rs
@@ -316,10 +316,9 @@ struct PendingTool {
     utf8_decoder: Utf8Decoder,
     /// Stashed `started_at` from eager creation. The eagerly-created block
     /// is `ToolCallBlock::Other`; when the refinement arrives with the real
-    /// kind, `transfer_timing_from` can't cross variant boundaries
-    /// (Other → Search, etc.) and would silently drop the timing. This
-    /// field preserves the instant so `set_started_at` can apply it to
-    /// whatever variant the refined block becomes.
+    /// kind, replacing it across variant boundaries (Other → Search, etc.)
+    /// would otherwise drop the timing. This field preserves the instant so
+    /// `set_started_at` can apply it to whatever variant the refined block becomes.
     started_at: Option<std::time::Instant>,
 }
 /// Streaming UTF-8 decoder for incremental byte deltas.

--- a/crates/codegen/xai-grok-pager/src/app/agent_view/render.rs
+++ b/crates/codegen/xai-grok-pager/src/app/agent_view/render.rs
@@ -109,7 +109,123 @@ impl AgentView {
             PlanApprovalFocus::Preview => vec![],
         }
     }
+    /// Returns the *exact* hints the bottom shortcuts bar would render right now.
+    ///
+    /// Single source of truth for context-sensitive shortcuts (pane, overlays,
+    /// sub-modes, selection state, turn running, plan/queue). Both the bar
+    /// renderer and the Ctrl+. cheatsheet Current section delegate here, so
+    /// they are guaranteed identical and every shortcut makes sense in the
+    /// active context.
+    ///
+    /// Known transient: when a subagent is fullscreen (`active_subagent.is_some()`),
+    /// draw returns early and the child renders its own bar; Current on the parent
+    /// still reflects parent context (documented limitation, pre-existing before
+    /// this change).
+    pub fn current_shortcut_hints(&self, registry: &ActionRegistry) -> Vec<HintItem> {
+        use crate::views::shortcuts_bar::HintItem;
+        if let Some(ref viewer) = self.block_viewer {
+            viewer.shortcuts_hints()
+        } else if !self.permission_queue.is_empty() {
+            use crate::views::permission_view::PermissionFocus;
+            if let Some(perm) = self.permission_queue.front() {
+                match perm.focus {
+                    PermissionFocus::FollowupInput => {
+                        vec![
+                            HintItem::new(key!(Enter), "send"),
+                            HintItem::new(key!(Esc), "back"),
+                        ]
+                    }
+                    PermissionFocus::Options => {
+                        use crate::input::key::KeyShortcut;
+                        use crossterm::event::{KeyCode, KeyModifiers};
+                        let n = perm.options.len().min(9) as u8;
+                        let last_ch = char::from(b'0' + n.max(1));
+                        let last_key = KeyShortcut::new(KeyCode::Char(last_ch), KeyModifiers::NONE);
+                        let mut hints = vec![HintItem::paired(key!('1'), last_key, "select")];
+                        if perm.has_adjustable_scope() {
+                            hints.push(HintItem::paired(key!(Left), key!(Right), "scope"));
+                        }
+                        if !perm.description.is_empty() {
+                            let label = if perm.args_expanded {
+                                "collapse"
+                            } else {
+                                "expand"
+                            };
+                            hints.push(HintItem::new(key!('f', CONTROL), label));
+                        }
+                        hints.push(HintItem::new(key!('o', CONTROL), "always-approve"));
+                        hints.push(HintItem::new(key!('c', CONTROL), "cancel"));
+                        hints
+                    }
+                }
+            } else {
+                unreachable!("permission_queue non-empty per outer guard")
+            }
+        } else if let Some(ref pav) = self.plan_approval_view {
+            self.plan_approval_shortcut_hints(pav)
+        } else if self.line_viewer.is_some() && self.is_plan_viewer() {
+            let suppress_shortcuts = self
+                .line_viewer
+                .as_ref()
+                .is_some_and(|v| v.fullscreen && v.list_state.input_mode().is_some());
+            if suppress_shortcuts {
+                vec![]
+            } else if self.is_casual_commenting() {
+                vec![
+                    HintItem::new(key!(Enter), "save comment"),
+                    HintItem::new(key!(Esc), "cancel"),
+                ]
+            } else {
+                let mut h = vec![
+                    HintItem::new(key!('c'), "comment"),
+                    HintItem::new(key!('f', CONTROL), "fullscreen"),
+                ];
+                if !self.plan_comments.is_empty() {
+                    h.push(HintItem::new(key!('s'), "send"));
+                }
+                h.push(HintItem::new(key!(Esc), "close"));
+                h
+            }
+        } else if let Some(ref qv) = self.question_view {
+            use crate::views::question_view::QuestionFocus;
+            match qv.focus {
+                QuestionFocus::InputMode => {
+                    if self.prompt.file_search_visible() {
+                        vec![
+                            HintItem::paired(key!(Up), key!(Down), "nav"),
+                            HintItem::new(key!(Tab), "accept"),
+                            HintItem::new(key!(Right), "drill"),
+                            HintItem::new(key!(Esc), "dismiss"),
+                        ]
+                    } else {
+                        vec![
+                            HintItem::new(key!(Enter), "submit"),
+                            HintItem::new(key!(Esc), "back"),
+                        ]
+                    }
+                }
+                QuestionFocus::Navigation => {
+                    vec![
+                        HintItem::new(key!(Esc), "unselect"),
+                        HintItem::new(key!(Tab), "scrollback"),
+                        HintItem::new(key!('X'), "dismiss"),
+                    ]
+                }
+            }
+        } else if self.cancel_turn_view.is_some() {
+            vec![
+                HintItem::paired(key!('1'), key!('4'), "select"),
+                HintItem::new(key!(Enter), "confirm"),
+                HintItem::new(key!(Esc), "keep running"),
+                HintItem::new(key!(Tab), "scrollback"),
+            ]
+        } else {
+            self.normal_pane_hints(registry)
+        }
+    }
     /// Shared "normal pane" hints: flag computation + `build_hints` + queue hint.
+    /// Single source of truth for the two former duplicated blocks in
+    /// `current_shortcut_hints` and `draw`.
     fn normal_pane_hints(&self, registry: &ActionRegistry) -> Vec<HintItem> {
         let fold_label = self.selected_fold_label();
         let is_editing = matches!(self.prompt_mode, PromptMode::EditingQueued { .. });

--- a/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/edit.rs
+++ b/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/edit.rs
@@ -828,16 +828,6 @@ impl EditToolCallBlock {
         self.error.is_none()
     }
 
-    /// Set error (mutable) — compute elapsed time if not already set (Phase 2).
-    pub fn set_error(&mut self, error: Option<String>) {
-        if self.elapsed_ms.is_none()
-            && let Some(start) = self.started_at
-        {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
-        self.error = error;
-    }
-
     /// Finalize elapsed time from `started_at`.
     ///
     /// Idempotent: no-op if `started_at` is `None` (pre-completed block)

--- a/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/execute.rs
+++ b/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/execute.rs
@@ -93,16 +93,6 @@ impl ExecuteToolCallBlock {
         }
     }
 
-    /// Set error (mutable) — compute elapsed time if not already set (Phase 2).
-    pub fn set_error(&mut self, error: Option<String>) {
-        if self.elapsed_ms.is_none()
-            && let Some(start) = self.started_at
-        {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
-        self.error = error;
-    }
-
     /// Check if successful (no error).
     pub fn is_success(&self) -> bool {
         self.error.is_none()

--- a/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/list_dir.rs
+++ b/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/list_dir.rs
@@ -59,16 +59,6 @@ impl ListDirToolCallBlock {
         self.error.is_none()
     }
 
-    /// Set error (mutable) — compute elapsed time if not already set (Phase 2).
-    pub fn set_error(&mut self, error: Option<String>) {
-        if self.elapsed_ms.is_none()
-            && let Some(start) = self.started_at
-        {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
-        self.error = error;
-    }
-
     /// Finalize elapsed time from `started_at`.
     ///
     /// Idempotent: no-op if `started_at` is `None` (pre-completed block)
@@ -90,11 +80,6 @@ impl ListDirToolCallBlock {
                 .started_at
                 .map(|start| start.elapsed().as_millis() as i64),
         }
-    }
-
-    /// Set output (mutable).
-    pub fn set_output(&mut self, output: impl Into<String>) {
-        self.output = output.into();
     }
 
     fn collapsed_line(&self, theme: &Theme, muted: bool, width: Option<usize>) -> Line<'static> {

--- a/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/memory_search.rs
+++ b/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/memory_search.rs
@@ -47,15 +47,6 @@ impl MemorySearchToolCallBlock {
         self.error.is_none()
     }
 
-    pub fn set_error(&mut self, error: Option<String>) {
-        if self.elapsed_ms.is_none()
-            && let Some(start) = self.started_at
-        {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
-        self.error = error;
-    }
-
     pub fn finish(&mut self) {
         if self.elapsed_ms.is_some() {
             return;

--- a/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/mod.rs
+++ b/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/mod.rs
@@ -291,52 +291,6 @@ impl BlockContent for ToolCallBlock {
 }
 
 impl ToolCallBlock {
-    /// Transfer timing data from another block of the same variant.
-    ///
-    /// Used when a running block is replaced with its completed version
-    /// (e.g., in `handle_tool_call_update` completion path). The new block
-    /// inherits `started_at` from the old block so `finish()` can compute
-    /// real elapsed time.
-    pub fn transfer_timing_from(&mut self, old: &ToolCallBlock) {
-        match (self, old) {
-            (ToolCallBlock::Execute(new), ToolCallBlock::Execute(old)) => {
-                new.started_at = old.started_at;
-            }
-            (ToolCallBlock::Read(new), ToolCallBlock::Read(old)) => {
-                new.started_at = old.started_at;
-            }
-            (ToolCallBlock::Edit(new), ToolCallBlock::Edit(old)) => {
-                new.started_at = old.started_at;
-            }
-            (ToolCallBlock::Search(new), ToolCallBlock::Search(old)) => {
-                new.started_at = old.started_at;
-            }
-            (ToolCallBlock::ListDir(new), ToolCallBlock::ListDir(old)) => {
-                new.started_at = old.started_at;
-            }
-            (ToolCallBlock::WebFetch(new), ToolCallBlock::WebFetch(old)) => {
-                new.started_at = old.started_at;
-            }
-            (ToolCallBlock::WebSearch(new), ToolCallBlock::WebSearch(old)) => {
-                new.started_at = old.started_at;
-            }
-            (ToolCallBlock::IntegrationSearch(new), ToolCallBlock::IntegrationSearch(old)) => {
-                new.started_at = old.started_at;
-            }
-            (ToolCallBlock::UseTool(new), ToolCallBlock::UseTool(old)) => {
-                new.started_at = old.started_at;
-            }
-            (ToolCallBlock::Skill(new), ToolCallBlock::Skill(old)) => {
-                new.started_at = old.started_at;
-            }
-            (ToolCallBlock::Other(new), ToolCallBlock::Other(old)) => {
-                new.started_at = old.started_at;
-            }
-            // Variant mismatch (shouldn't happen in practice) — skip.
-            _ => {}
-        }
-    }
-
     /// Whether the tool call finished without an error.
     pub fn is_success(&self) -> bool {
         match self {
@@ -358,9 +312,8 @@ impl ToolCallBlock {
 
     /// Set `started_at` on the inner variant block.
     ///
-    /// Unlike `transfer_timing_from`, this works across variant boundaries
-    /// (e.g. setting `started_at` on a `Search` block from a value captured
-    /// when the block was still `Other`).
+    /// This works across variant boundaries (e.g. setting `started_at` on a
+    /// `Search` block from a value captured when the block was still `Other`).
     pub fn set_started_at(&mut self, instant: std::time::Instant) {
         match self {
             ToolCallBlock::Execute(b) => b.started_at = Some(instant),

--- a/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/other.rs
+++ b/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/other.rs
@@ -100,16 +100,6 @@ impl OtherToolCallBlock {
         None
     }
 
-    /// Set error (mutable) — compute elapsed time if not already set (Phase 2).
-    pub fn set_error(&mut self, error: Option<String>) {
-        if self.elapsed_ms.is_none()
-            && let Some(start) = self.started_at
-        {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
-        self.error = error;
-    }
-
     /// Finalize elapsed time from `started_at`.
     ///
     /// Idempotent: no-op if `started_at` is `None` (pre-completed block)

--- a/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/read.rs
+++ b/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/read.rs
@@ -112,16 +112,6 @@ impl ReadToolCallBlock {
         self.skill_name().is_some()
     }
 
-    /// Set error (mutable) — compute elapsed time if not already set (Phase 2).
-    pub fn set_error(&mut self, error: Option<String>) {
-        if self.elapsed_ms.is_none()
-            && let Some(start) = self.started_at
-        {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
-        self.error = error;
-    }
-
     /// Finalize elapsed time from `started_at`.
     ///
     /// Idempotent: no-op if `started_at` is `None` (pre-completed block)

--- a/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/search.rs
+++ b/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/search.rs
@@ -129,16 +129,6 @@ impl SearchToolCallBlock {
         self.error.is_none()
     }
 
-    /// Set error (mutable) — compute elapsed time if not already set (Phase 2).
-    pub fn set_error(&mut self, error: Option<String>) {
-        if self.elapsed_ms.is_none()
-            && let Some(start) = self.started_at
-        {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
-        self.error = error;
-    }
-
     /// Finalize elapsed time from `started_at`.
     ///
     /// Idempotent: no-op if `started_at` is `None` (pre-completed block)
@@ -160,12 +150,6 @@ impl SearchToolCallBlock {
                 .started_at
                 .map(|start| start.elapsed().as_millis() as i64),
         }
-    }
-
-    /// Set file matches (mutable).
-    pub fn set_file_matches(&mut self, match_count: usize, file_matches: Vec<SearchFileMatch>) {
-        self.match_count = match_count;
-        self.file_matches = file_matches;
     }
 
     /// Build the match summary string, adapted by output mode.

--- a/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/search_tool.rs
+++ b/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/search_tool.rs
@@ -72,24 +72,6 @@ impl SearchToolCallBlock {
         self.error.is_none()
     }
 
-    pub fn set_error(&mut self, error: Option<String>) {
-        if self.elapsed_ms.is_none()
-            && let Some(start) = self.started_at
-        {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
-        self.error = error;
-    }
-
-    pub fn finish(&mut self) {
-        if self.elapsed_ms.is_some() {
-            return;
-        }
-        if let Some(start) = self.started_at {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
-    }
-
     pub fn elapsed_ms(&self) -> Option<i64> {
         self.elapsed_ms.or_else(|| {
             self.started_at

--- a/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/use_tool.rs
+++ b/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/use_tool.rs
@@ -43,31 +43,8 @@ impl UseToolCallBlock {
         }
     }
 
-    pub fn with_error(mut self, error: impl Into<String>) -> Self {
-        self.error = Some(error.into());
-        self
-    }
-
     pub fn is_success(&self) -> bool {
         self.error.is_none()
-    }
-
-    pub fn set_error(&mut self, error: Option<String>) {
-        if self.elapsed_ms.is_none()
-            && let Some(start) = self.started_at
-        {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
-        self.error = error;
-    }
-
-    pub fn finish(&mut self) {
-        if self.elapsed_ms.is_some() {
-            return;
-        }
-        if let Some(start) = self.started_at {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
     }
 
     pub fn elapsed_ms(&self) -> Option<i64> {

--- a/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/web_fetch.rs
+++ b/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/web_fetch.rs
@@ -69,15 +69,6 @@ impl WebFetchToolCallBlock {
         self.output.clone().unwrap_or_default()
     }
 
-    pub fn set_error(&mut self, error: Option<String>) {
-        if self.elapsed_ms.is_none()
-            && let Some(start) = self.started_at
-        {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
-        self.error = error;
-    }
-
     pub fn finish(&mut self) {
         if self.elapsed_ms.is_some() {
             return;

--- a/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/web_search.rs
+++ b/crates/codegen/xai-grok-pager/src/scrollback/blocks/tool/web_search.rs
@@ -68,15 +68,6 @@ impl WebSearchToolCallBlock {
         self.content.as_deref().unwrap_or_default().to_owned()
     }
 
-    pub fn set_error(&mut self, error: Option<String>) {
-        if self.elapsed_ms.is_none()
-            && let Some(start) = self.started_at
-        {
-            self.elapsed_ms = Some(start.elapsed().as_millis() as i64);
-        }
-        self.error = error;
-    }
-
     pub fn finish(&mut self) {
         if self.elapsed_ms.is_some() {
             return;

--- a/crates/codegen/xai-grok-pager/src/tool_usage.rs
+++ b/crates/codegen/xai-grok-pager/src/tool_usage.rs
@@ -559,8 +559,7 @@ mod tests {
             &ToolCallBlock::Execute(success)
         ));
 
-        let mut failed = ExecuteToolCallBlock::new("bad");
-        failed.set_error(Some("error".into()));
+        let failed = ExecuteToolCallBlock::new("bad").with_error("error");
         assert!(!ToolUsageStats::tool_block_is_success(
             &ToolCallBlock::Execute(failed)
         ));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore `AgentView::current_shortcut_hints`, which new `main` pager tests use as an inspection API
- remove superseded per-tool mutators in pager scrollback blocks after verifying zero workspace callers
- migrate the sole test caller from `set_error` to the live `with_error` builder
- remove stale timing documentation tied to a deleted helper

## Result
- Hawk findings: **565 → 549** (`-16`)
- source diff: **194 deletions / 122 additions** (`-72` net lines, including the 116-line API restoration)

## Verification
- both new-main tests that call `current_shortcut_hints` pass
- full `xai-grok-pager` suite: **7,756 passed**, 10 ignored
- `cargo fmt --all -- --check`
- `cargo clippy --locked -p xai-grok-pager --all-targets`
- final `cargo +1.97.1 hawk check ...`: 549 findings, exit 0
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f8b02-b749-7990-90c5-84a547a3c712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f8b02-b749-7990-90c5-84a547a3c712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

