### PR TITLE
Add DeepSeek Responses API support for V4 Flash (0731)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,7 @@ Three independent axes: **`ApiBackend`** × **`ProviderProfile`** × **`AuthSche
 | Kimi Platform | `auth.json` scope `kimi::api_key` | Isolated from Kimi Code |
 | Kimi Code | `auth.json` scope `kimi_code::api_key` | Isolated from Platform |
 | Fireworks AI | `auth.json` scope `fireworks::api_key` | Curated model list; `/login fireworks` |
+| DeepSeek direct | `auth.json` scope `deepseek::api_key` | Chat + Responses (V4 Flash); `/login deepseek` |
 
 After any non-xAI profile that denies xAI services, the session export boundary closes monotonically (compatibility field still named `ever_used_codex`).
 

--- a/crates/codegen/xai-grok-models/default_models.json
+++ b/crates/codegen/xai-grok-models/default_models.json
@@ -193,27 +193,38 @@
       "id": "deepseek:deepseek-v4-pro",
       "model": "deepseek-v4-pro",
       "name": "DeepSeek V4 Pro",
-      "description": "DeepSeek V4 Pro through the direct DeepSeek API",
+      "description": "DeepSeek V4 Pro through the direct DeepSeek Chat Completions API",
       "base_url": "https://api.deepseek.com",
       "context_window": 1000000,
       "api_backend": "chat_completions",
       "provider": "deepseek",
       "env_key": "DEEPSEEK_API_KEY",
       "tool_mode": "direct",
-      "supported_in_api": true
+      "supported_in_api": true,
+      "reasoning_efforts": [
+        { "value": "low", "description": "Faster responses with lighter reasoning" },
+        { "value": "high", "description": "Default DeepSeek reasoning depth for agentic work", "default": true },
+        { "value": "max", "description": "Maximum reasoning depth for the hardest problems" }
+      ]
     },
     {
       "id": "deepseek:deepseek-v4-flash",
       "model": "deepseek-v4-flash",
       "name": "DeepSeek V4 Flash",
-      "description": "DeepSeek V4 Flash through the direct DeepSeek API",
+      "description": "DeepSeek V4 Flash (0731) through the direct DeepSeek Responses API",
       "base_url": "https://api.deepseek.com",
       "context_window": 1000000,
-      "api_backend": "chat_completions",
+      "api_backend": "responses",
       "provider": "deepseek",
       "env_key": "DEEPSEEK_API_KEY",
       "tool_mode": "direct",
-      "supported_in_api": true
+      "supported_in_api": true,
+      "reasoning_efforts": [
+        { "value": "none", "description": "Disable thinking mode" },
+        { "value": "low", "description": "Faster responses with lighter reasoning" },
+        { "value": "high", "description": "Default DeepSeek reasoning depth for agentic work", "default": true },
+        { "value": "max", "description": "Maximum reasoning depth for the hardest problems" }
+      ]
     },
     {
       "model": "gpt-5.6-sol",

--- a/crates/codegen/xai-grok-pager/docs/user-guide/05-configuration.md
+++ b/crates/codegen/xai-grok-pager/docs/user-guide/05-configuration.md
@@ -339,7 +339,8 @@ context_window = 1040000
 DeepSeek API direct is a separate API-key-only provider. Configure it from
 Settings or `/login deepseek`, or export `DEEPSEEK_API_KEY`. Open Grok refreshes
 the curated direct catalog against DeepSeek's models endpoint and keeps these
-credentials isolated from Fireworks-hosted DeepSeek models:
+credentials isolated from Fireworks-hosted DeepSeek models. V4 Pro uses Chat
+Completions; V4 Flash (0731) uses DeepSeek's native Responses API:
 
 ```toml
 [model.deepseek-v4-pro-direct]
@@ -348,6 +349,15 @@ name = "DeepSeek V4 Pro"
 provider = "deepseek"
 base_url = "https://api.deepseek.com"
 api_backend = "chat_completions"
+env_key = "DEEPSEEK_API_KEY"
+context_window = 1000000
+
+[model.deepseek-v4-flash-direct]
+model = "deepseek-v4-flash"
+name = "DeepSeek V4 Flash"
+provider = "deepseek"
+base_url = "https://api.deepseek.com"
+api_backend = "responses"
 env_key = "DEEPSEEK_API_KEY"
 context_window = 1000000
 ```

--- a/crates/codegen/xai-grok-sampler/src/client.rs
+++ b/crates/codegen/xai-grok-sampler/src/client.rs
@@ -3438,6 +3438,10 @@ mod tests {
                 validate_responses_wire_body_for_provider(&body, ModelProvider::Xai),
                 Err(SamplingError::InvalidConfiguration(_))
             ));
+            assert!(matches!(
+                validate_responses_wire_body_for_provider(&body, ModelProvider::DeepSeek),
+                Err(SamplingError::InvalidConfiguration(_))
+            ));
             validate_responses_wire_body_for_provider(&body, ModelProvider::Codex)
                 .expect("Codex supports native custom Responses content");
         }
@@ -4013,6 +4017,31 @@ mod tests {
             ..minimal_config()
         };
         assert!(SamplingClient::new(config).is_ok());
+    }
+
+    #[test]
+    fn deepseek_accepts_chat_and_responses_clients() {
+        for backend in [ApiBackend::ChatCompletions, ApiBackend::Responses] {
+            let config = SamplerConfig {
+                provider: ModelProvider::DeepSeek,
+                api_backend: backend,
+                ..minimal_config()
+            };
+            assert!(
+                SamplingClient::new(config).is_ok(),
+                "DeepSeek must accept {backend:?}"
+            );
+        }
+
+        let config = SamplerConfig {
+            provider: ModelProvider::DeepSeek,
+            api_backend: ApiBackend::Messages,
+            ..minimal_config()
+        };
+        assert!(matches!(
+            SamplingClient::new(config),
+            Err(SamplingError::InvalidConfiguration(_))
+        ));
     }
 
     #[test]

--- a/crates/codegen/xai-grok-sampler/src/provider.rs
+++ b/crates/codegen/xai-grok-sampler/src/provider.rs
@@ -280,9 +280,9 @@ pub trait ProviderAdapter: std::fmt::Debug + Send + Sync {
     fn normalizes_response_events(&self) -> bool {
         match self.profile().responses_dialect() {
             None => false,
-            Some(
-                ResponsesDialect::Xai | ResponsesDialect::Codex | ResponsesDialect::DeepSeek,
-            ) => true,
+            Some(ResponsesDialect::Xai | ResponsesDialect::Codex | ResponsesDialect::DeepSeek) => {
+                true
+            }
         }
     }
 

--- a/crates/codegen/xai-grok-sampler/src/provider.rs
+++ b/crates/codegen/xai-grok-sampler/src/provider.rs
@@ -163,13 +163,16 @@ pub trait ProviderAdapter: std::fmt::Debug + Send + Sync {
         match self.profile().responses_dialect() {
             None | Some(ResponsesDialect::Xai) => {}
             Some(ResponsesDialect::Codex) => patch_codex_responses_request(request_body, policy),
+            Some(ResponsesDialect::DeepSeek) => {
+                patch_deepseek_responses_request(request_body, policy)
+            }
         }
     }
 
     /// Return the provider-owned cache key derived from stable request state.
     fn prompt_cache_key(&self, session_id: Option<&str>) -> Option<String> {
         match self.profile().responses_dialect() {
-            None | Some(ResponsesDialect::Xai) => None,
+            None | Some(ResponsesDialect::Xai | ResponsesDialect::DeepSeek) => None,
             Some(ResponsesDialect::Codex) => session_id
                 .filter(|session_id| !session_id.is_empty())
                 .map(str::to_owned),
@@ -246,7 +249,7 @@ pub trait ProviderAdapter: std::fmt::Debug + Send + Sync {
         }
 
         match self.profile().responses_dialect() {
-            None | Some(ResponsesDialect::Xai) => {}
+            None | Some(ResponsesDialect::Xai | ResponsesDialect::DeepSeek) => {}
             Some(ResponsesDialect::Codex) => {
                 let value = parsed
                     .as_ref()
@@ -272,17 +275,22 @@ pub trait ProviderAdapter: std::fmt::Debug + Send + Sync {
         self.profile().request_metadata == RequestMetadataPolicy::XGrokHeaders
     }
 
-    /// Both current dialects need the dependency-boundary compatibility pass.
+    /// Dialects that speak Responses need the dependency-boundary compatibility
+    /// pass so typed async-openai gaps do not break streaming.
     fn normalizes_response_events(&self) -> bool {
         match self.profile().responses_dialect() {
             None => false,
-            Some(ResponsesDialect::Xai | ResponsesDialect::Codex) => true,
+            Some(
+                ResponsesDialect::Xai | ResponsesDialect::Codex | ResponsesDialect::DeepSeek,
+            ) => true,
         }
     }
 
     fn ignores_unknown_response_event(&self, error: &SamplingError, data: &str) -> bool {
-        self.profile().responses_dialect() == Some(ResponsesDialect::Codex)
-            && is_unknown_top_level_response_event(error, data)
+        matches!(
+            self.profile().responses_dialect(),
+            Some(ResponsesDialect::Codex | ResponsesDialect::DeepSeek)
+        ) && is_unknown_top_level_response_event(error, data)
     }
 }
 
@@ -528,6 +536,34 @@ pub fn provider_adapter(provider: ModelProvider) -> &'static dyn ProviderAdapter
         ModelProvider::Fireworks => PROVIDER_REGISTRY[3].adapter,
         ModelProvider::DeepSeek => PROVIDER_REGISTRY[4].adapter,
         ModelProvider::OpenCodeGo => PROVIDER_REGISTRY[5].adapter,
+    }
+}
+
+fn patch_deepseek_responses_request(request_body: &mut Value, policy: ResponsesRequestPolicy) {
+    // DeepSeek's Responses API is explicitly stateless.
+    request_body["store"] = Value::Bool(false);
+    if let Some(object) = request_body.as_object_mut() {
+        object.remove("previous_response_id");
+        object.remove("prompt_cache_key");
+        object.remove("prompt_cache_retention");
+    }
+
+    // Summary is accepted but never produced; keep the wire minimal.
+    if let Some(reasoning) = request_body
+        .get_mut("reasoning")
+        .and_then(Value::as_object_mut)
+    {
+        reasoning.remove("summary");
+    }
+
+    // async-openai maps Max/Ultra onto xhigh; DeepSeek's max effort must stay
+    // the literal "max" value documented for V4 Flash Responses.
+    if matches!(
+        policy.local_effort,
+        Some(ReasoningEffort::Max | ReasoningEffort::Ultra)
+    ) {
+        ensure_reasoning_object(request_body);
+        request_body["reasoning"]["effort"] = Value::String("max".to_owned());
     }
 }
 
@@ -778,15 +814,43 @@ mod tests {
                 },
             );
 
-            if provider != ModelProvider::Codex {
-                assert_eq!(request, original);
-            } else {
-                assert_eq!(request["instructions"], "base prompt");
-                assert_eq!(request["input"].as_array().unwrap().len(), 1);
-                assert_eq!(request["reasoning"]["effort"], "max");
-                assert!(request["reasoning"].get("summary").is_none());
+            match provider {
+                ModelProvider::Codex => {
+                    assert_eq!(request["instructions"], "base prompt");
+                    assert_eq!(request["input"].as_array().unwrap().len(), 1);
+                    assert_eq!(request["reasoning"]["effort"], "max");
+                    assert!(request["reasoning"].get("summary").is_none());
+                }
+                ModelProvider::DeepSeek => {
+                    assert_eq!(request["store"], false);
+                    assert_eq!(request["reasoning"]["effort"], "max");
+                    assert!(request["reasoning"].get("summary").is_none());
+                    assert!(request.get("previous_response_id").is_none());
+                    assert!(request.get("prompt_cache_key").is_none());
+                }
+                _ => assert_eq!(request, original),
             }
         }
+    }
+
+    #[test]
+    fn deepseek_accepts_responses_and_chat_backends() {
+        let deepseek = provider_adapter(ModelProvider::DeepSeek);
+        assert!(
+            deepseek
+                .validate_backend(&ApiBackend::ChatCompletions)
+                .is_ok()
+        );
+        assert!(deepseek.validate_backend(&ApiBackend::Responses).is_ok());
+        assert!(deepseek.validate_backend(&ApiBackend::Messages).is_err());
+        assert_eq!(deepseek.prompt_cache_key(Some("session")), None);
+        assert!(!deepseek.supports_turn_state(&ApiBackend::Responses));
+        assert!(!deepseek.sends_doom_loop_opt_in());
+        assert!(deepseek.normalizes_response_events());
+        assert_eq!(
+            deepseek.profile().responses_dialect(),
+            Some(ResponsesDialect::DeepSeek)
+        );
     }
 
     #[test]
@@ -834,6 +898,19 @@ mod tests {
         );
         assert!(fireworks.validate_backend(&ApiBackend::Responses).is_err());
         assert!(fireworks.validate_backend(&ApiBackend::Messages).is_err());
+
+        let deepseek = provider_adapter(ModelProvider::DeepSeek);
+        assert_eq!(deepseek.prompt_cache_key(Some("session")), None);
+        assert!(!deepseek.supports_turn_state(&ApiBackend::Responses));
+        assert!(!deepseek.sends_doom_loop_opt_in());
+        assert!(deepseek.normalizes_response_events());
+        assert!(
+            deepseek
+                .validate_backend(&ApiBackend::ChatCompletions)
+                .is_ok()
+        );
+        assert!(deepseek.validate_backend(&ApiBackend::Responses).is_ok());
+        assert!(deepseek.validate_backend(&ApiBackend::Messages).is_err());
     }
 
     #[test]

--- a/crates/codegen/xai-grok-sampling-types/src/conversation.rs
+++ b/crates/codegen/xai-grok-sampling-types/src/conversation.rs
@@ -1620,6 +1620,10 @@ impl ConversationRequest {
                     (Some(crate::ResponsesDialect::Xai), BackendToolKind::XSearch(call)) => {
                         Some(x_search_call_wire_value(call))
                     }
+                    // DeepSeek Responses has no opaque provider-native history
+                    // carriers today; keep the match explicit so new dialects
+                    // fail closed until their replay contract is defined.
+                    (Some(crate::ResponsesDialect::DeepSeek), _) => None,
                     _ => None,
                 };
                 if let Some(value) = value {
@@ -13067,6 +13071,12 @@ mod tests {
             assert_eq!(replacements[0].input_item_index, case.expected_index);
             assert_eq!(replacements[0].value["type"], case.expected_type);
         }
+        assert!(
+            request
+                .raw_responses_input_replacements(crate::ModelProvider::DeepSeek)
+                .is_empty(),
+            "DeepSeek Responses must not replay xAI or Codex opaque history"
+        );
     }
 
     #[test]

--- a/crates/codegen/xai-grok-sampling-types/src/types.rs
+++ b/crates/codegen/xai-grok-sampling-types/src/types.rs
@@ -971,13 +971,16 @@ pub enum ModelProvider {
 
 /// Provider-specific wire contract used by the Responses API.
 ///
-/// This remains separate from [`ApiBackend`]: both built-in providers use the
+/// This remains separate from [`ApiBackend`]: multiple providers use the
 /// Responses endpoint, but they require different request and replay shapes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ResponsesDialect {
     Xai,
     Codex,
+    /// DeepSeek's native OpenAI-compatible Responses API (V4 Flash and later).
+    /// Stateless (`store: false`), with DeepSeek-owned reasoning-effort mapping.
+    DeepSeek,
 }
 
 /// Wire representation used for Code Mode's client-executed `exec` tool.
@@ -1189,14 +1192,16 @@ impl ProviderProfile {
         xai_services: XaiServicePolicy::Denied,
     };
 
-    /// DeepSeek's direct OpenAI-compatible inference API. DeepSeek uses
-    /// ordinary client-side function tools over Chat Completions and
-    /// authenticates with a provider-owned API key only.
+    /// DeepSeek's direct OpenAI-compatible inference API. Chat Completions
+    /// remains available for every curated model; Responses is enabled for the
+    /// DeepSeek dialect used by V4 Flash (and later Responses-capable models).
+    /// Hosted search stays off at the profile layer so Chat-only models keep
+    /// client-side search routing. Authenticates with a provider-owned API key.
     pub const DEEPSEEK: Self = Self {
         provider: ModelProvider::DeepSeek,
         backends: ProviderBackends {
             chat_completions: true,
-            responses: None,
+            responses: Some(ResponsesDialect::DeepSeek),
             messages: false,
         },
         code_mode_transport: CodeModeTransport::Unsupported,
@@ -1613,7 +1618,7 @@ mod tests {
                 name: "DeepSeek",
                 backends: ProviderBackends {
                     chat_completions: true,
-                    responses: None,
+                    responses: Some(ResponsesDialect::DeepSeek),
                     messages: false,
                 },
                 code_mode_transport: CodeModeTransport::Unsupported,

--- a/crates/codegen/xai-grok-shell/src/deepseek_models.rs
+++ b/crates/codegen/xai-grok-shell/src/deepseek_models.rs
@@ -1,9 +1,9 @@
 //! Provider-isolated DeepSeek direct model discovery.
 //!
-//! DeepSeek serves an OpenAI-compatible Chat Completions API. The provider's
-//! `/models` endpoint is authoritative for the curated direct-model partition;
-//! unknown future model ids fail closed until their limits and capabilities are
-//! reviewed here.
+//! DeepSeek serves OpenAI-compatible Chat Completions and, for V4 Flash, a
+//! native Responses API. The provider's `/models` endpoint is authoritative for
+//! the curated direct-model partition; unknown future model ids fail closed
+//! until their limits and capabilities are reviewed here.
 
 use crate::agent::config::{EnvKeys, ModelEntry, ModelInfo};
 use anyhow::{Context, anyhow};
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use std::num::NonZeroU64;
 use std::time::Duration;
 use url::Url;
-use xai_grok_sampling_types::{ApiBackend, ModelProvider, ToolMode};
+use xai_grok_sampling_types::{ApiBackend, ModelProvider, ReasoningEffort, ToolMode};
 
 pub const DEEPSEEK_API_BASE_URL: &str = "https://api.deepseek.com";
 pub const DEEPSEEK_API_BASE_URL_ENV: &str = "OPENGROK_DEEPSEEK_API_BASE_URL";
@@ -26,6 +26,7 @@ pub struct CuratedDeepSeekModel {
     pub name: &'static str,
     pub description: &'static str,
     pub context_window: u64,
+    pub api_backend: ApiBackend,
 }
 
 pub const CURATED_DEEPSEEK_MODELS: [CuratedDeepSeekModel; 2] = [
@@ -33,15 +34,17 @@ pub const CURATED_DEEPSEEK_MODELS: [CuratedDeepSeekModel; 2] = [
         key: "deepseek:deepseek-v4-pro",
         slug: "deepseek-v4-pro",
         name: "DeepSeek V4 Pro",
-        description: "DeepSeek V4 Pro through the direct DeepSeek API",
+        description: "DeepSeek V4 Pro through the direct DeepSeek Chat Completions API",
         context_window: 1_000_000,
+        api_backend: ApiBackend::ChatCompletions,
     },
     CuratedDeepSeekModel {
         key: "deepseek:deepseek-v4-flash",
         slug: "deepseek-v4-flash",
         name: "DeepSeek V4 Flash",
-        description: "DeepSeek V4 Flash through the direct DeepSeek API",
+        description: "DeepSeek V4 Flash (0731) through the direct DeepSeek Responses API",
         context_window: 1_000_000,
+        api_backend: ApiBackend::Responses,
     },
 ];
 
@@ -98,6 +101,72 @@ fn credential_fingerprint(api_key: &str) -> String {
     blake3::hash(api_key.as_bytes()).to_hex().to_string()
 }
 
+fn reasoning_effort_option(
+    value: ReasoningEffort,
+    description: &str,
+    default: bool,
+) -> xai_grok_sampling_types::ReasoningEffortOption {
+    let id = value.as_str().to_owned();
+    xai_grok_sampling_types::ReasoningEffortOption {
+        label: match value {
+            ReasoningEffort::None => "None".to_owned(),
+            ReasoningEffort::Low => "Low".to_owned(),
+            ReasoningEffort::High => "High".to_owned(),
+            ReasoningEffort::Max => "Max".to_owned(),
+            other => other.as_str().to_owned(),
+        },
+        id,
+        value,
+        description: Some(description.to_owned()),
+        default,
+    }
+}
+
+fn curated_reasoning_efforts(
+    curated: &CuratedDeepSeekModel,
+) -> Vec<xai_grok_sampling_types::ReasoningEffortOption> {
+    match curated.api_backend {
+        // Responses documents none/low/high/max for V4 Flash thinking control.
+        ApiBackend::Responses => vec![
+            reasoning_effort_option(ReasoningEffort::None, "Disable thinking mode", false),
+            reasoning_effort_option(
+                ReasoningEffort::Low,
+                "Faster responses with lighter reasoning",
+                false,
+            ),
+            reasoning_effort_option(
+                ReasoningEffort::High,
+                "Default DeepSeek reasoning depth for agentic work",
+                true,
+            ),
+            reasoning_effort_option(
+                ReasoningEffort::Max,
+                "Maximum reasoning depth for the hardest problems",
+                false,
+            ),
+        ],
+        // Chat Completions uses reasoning_effort with thinking enabled by default.
+        ApiBackend::ChatCompletions => vec![
+            reasoning_effort_option(
+                ReasoningEffort::Low,
+                "Faster responses with lighter reasoning",
+                false,
+            ),
+            reasoning_effort_option(
+                ReasoningEffort::High,
+                "Default DeepSeek reasoning depth for agentic work",
+                true,
+            ),
+            reasoning_effort_option(
+                ReasoningEffort::Max,
+                "Maximum reasoning depth for the hardest problems",
+                false,
+            ),
+        ],
+        ApiBackend::Messages => Vec::new(),
+    }
+}
+
 fn curated_model_entry(curated: &CuratedDeepSeekModel, base_url: &str) -> ModelEntry {
     let mut info = ModelInfo::fallback(curated.key);
     info.id = Some(curated.key.to_owned());
@@ -105,14 +174,19 @@ fn curated_model_entry(curated: &CuratedDeepSeekModel, base_url: &str) -> ModelE
     info.base_url = base_url.trim_end_matches('/').to_owned();
     info.name = Some(curated.name.to_owned());
     info.description = Some(curated.description.to_owned());
-    info.api_backend = ApiBackend::ChatCompletions;
+    info.api_backend = curated.api_backend;
     info.provider = ModelProvider::DeepSeek;
     info.tool_mode = Some(ToolMode::Direct);
     info.context_window =
         NonZeroU64::new(curated.context_window).expect("non-zero DeepSeek context window");
-    info.supports_reasoning_effort = false;
-    info.reasoning_efforts.clear();
-    info.reasoning_effort = None;
+    info.reasoning_efforts = curated_reasoning_efforts(curated);
+    info.supports_reasoning_effort = !info.reasoning_efforts.is_empty();
+    info.reasoning_effort = info
+        .reasoning_efforts
+        .iter()
+        .find(|opt| opt.default)
+        .or_else(|| info.reasoning_efforts.first())
+        .map(|opt| opt.value);
     info.supported_in_api = true;
     ModelEntry {
         info,
@@ -290,13 +364,16 @@ mod tests {
     }
 
     #[test]
-    fn wire_catalog_is_curated_namespaced_and_chat_only() {
+    fn wire_catalog_routes_flash_to_responses_and_pro_to_chat() {
         let client = DeepSeekModelsClient::with_base_url(DEEPSEEK_API_BASE_URL);
         let catalog = client.catalog_from_wire(
             DeepSeekModelsResponse {
                 data: vec![
                     DeepSeekWireModel {
                         id: "deepseek-v4-pro".to_owned(),
+                    },
+                    DeepSeekWireModel {
+                        id: "deepseek-v4-flash".to_owned(),
                     },
                     DeepSeekWireModel {
                         id: "future-unknown".to_owned(),
@@ -306,16 +383,40 @@ mod tests {
             "catalog-key",
         );
         let entries = catalog.entries();
-        assert_eq!(entries.len(), 1);
-        let entry = &entries["deepseek:deepseek-v4-pro"];
-        assert_eq!(entry.info.model, "deepseek-v4-pro");
-        assert_eq!(entry.info.provider, ModelProvider::DeepSeek);
-        assert_eq!(entry.info.api_backend, ApiBackend::ChatCompletions);
-        assert_eq!(entry.info.tool_mode, Some(ToolMode::Direct));
-        assert_eq!(entry.info.context_window.get(), 1_000_000);
+        assert_eq!(entries.len(), 2);
+
+        let pro = &entries["deepseek:deepseek-v4-pro"];
+        assert_eq!(pro.info.model, "deepseek-v4-pro");
+        assert_eq!(pro.info.provider, ModelProvider::DeepSeek);
+        assert_eq!(pro.info.api_backend, ApiBackend::ChatCompletions);
+        assert_eq!(pro.info.tool_mode, Some(ToolMode::Direct));
+        assert_eq!(pro.info.context_window.get(), 1_000_000);
+        assert!(pro.info.supports_reasoning_effort);
+        assert_eq!(pro.info.reasoning_effort, Some(ReasoningEffort::High));
         assert_eq!(
-            entry.env_key.as_ref().and_then(EnvKeys::primary),
+            pro.env_key.as_ref().and_then(EnvKeys::primary),
             Some(DEEPSEEK_API_KEY_ENV)
+        );
+
+        let flash = &entries["deepseek:deepseek-v4-flash"];
+        assert_eq!(flash.info.model, "deepseek-v4-flash");
+        assert_eq!(flash.info.provider, ModelProvider::DeepSeek);
+        assert_eq!(flash.info.api_backend, ApiBackend::Responses);
+        assert!(flash.info.supports_reasoning_effort);
+        assert_eq!(flash.info.reasoning_effort, Some(ReasoningEffort::High));
+        assert!(
+            flash
+                .info
+                .reasoning_efforts
+                .iter()
+                .any(|opt| opt.value == ReasoningEffort::None)
+        );
+        assert!(
+            flash
+                .info
+                .description
+                .as_deref()
+                .is_some_and(|text| text.contains("0731") && text.contains("Responses"))
         );
     }
 
@@ -357,7 +458,8 @@ mod tests {
 
         let client = DeepSeekModelsClient::with_base_url(format!("http://{address}"));
         let catalog = client.query_with_key("model-query-canary").await.unwrap();
-        assert!(catalog.entries().contains_key("deepseek:deepseek-v4-flash"));
+        let flash = &catalog.entries()["deepseek:deepseek-v4-flash"];
+        assert_eq!(flash.info.api_backend, ApiBackend::Responses);
         assert_eq!(
             capture.0.lock().unwrap().as_deref(),
             Some("Bearer model-query-canary")

--- a/docs/agents/providers.md
+++ b/docs/agents/providers.md
@@ -35,7 +35,7 @@ Adapters (credential-free): `xai-grok-sampler/src/provider.rs`.
 | OpenAI Codex | Responses | Codex | OpenAI | Codex OAuth | **denied** |
 | Kimi | Chat | none | client function tools | API key only | **denied** |
 | Fireworks AI | Chat | none | client function tools | API key only | **denied** |
-| DeepSeek direct | Chat | none | client function tools | API key only | **denied** |
+| DeepSeek direct | Chat, Responses (Flash) | DeepSeek | client function tools | API key only | **denied** |
 | OpenCode Go | Chat, Messages (per model) | none | client function tools | API key only | **denied** |
 
 ## Layer map (paths)
@@ -143,7 +143,7 @@ Also isolated:
 | --- | --- | --- | --- | --- | --- | --- |
 | Private headers | `x-grok-*` | stripped | stripped | stripped | stripped | stripped |
 | Doom-loop opt-in | yes | no | no | no | no | no |
-| Responses extras | minimal | Max/Ultra mapping, multi-agent mode, reasoning summary | N/A | N/A | N/A | N/A |
+| Responses extras | minimal | Max/Ultra mapping, multi-agent mode, reasoning summary | N/A | N/A | Max→`max`, strip summary, force `store: false` | N/A |
 | Prompt cache key | no | session id | no | no | no | no |
 | Sticky turn state | no | `x-codex-turn-state` | no | no | no | no |
 | Unknown `response.*` events | strict | ignore unknown side-channels when opted | N/A | N/A | N/A | N/A |

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -29,7 +29,7 @@ Codex provider does not override an explicit model API key.
 | OpenAI Codex | Responses | Codex | OpenAI | yes | standard only | Codex OAuth | denied |
 | Kimi | Chat | none | client function tools | no | standard only | provider API key | denied |
 | Fireworks AI | Chat | none | client function tools | no | standard only | provider API key | denied |
-| DeepSeek direct | Chat | none | client function tools | no | standard only | provider API key | denied |
+| DeepSeek direct | Chat, Responses (Flash) | DeepSeek | client function tools | no | standard only | provider API key | denied |
 | OpenCode Go | Chat, Messages | none | client function tools | no | standard only | provider API key | denied |
 
 The sampler's built-in `ProviderAdapter` registry applies the transport policy
@@ -43,9 +43,13 @@ hosted-tool dialect. The Fireworks AI adapter is a plain Chat Completions
 transport: standard sampling fields pass through unchanged and no hosted-tool
 dialect is advertised. Fireworks exposes a curated model list; its `/models`
 endpoint may enrich curated entries (context window) but can neither add nor
-remove models. The DeepSeek adapter uses ordinary Chat Completions and strips
-Open Grok's internal per-message model attribution before transport. Its live
-catalog intersects DeepSeek's `/models` response with curated direct entries.
+remove models. The DeepSeek adapter keeps Chat Completions for V4 Pro and routes V4 Flash
+through DeepSeek's native Responses dialect. Chat sanitization strips Open
+Grok's internal per-message model attribution before transport; Responses
+patching forces DeepSeek's stateless `store: false` contract and restores the
+literal `max` reasoning effort that async-openai would otherwise coerce to
+`xhigh`. Its live catalog intersects DeepSeek's `/models` response with curated
+direct entries.
 OpenCode Go selects Chat Completions or Messages per model from canonical
 metadata rather than from provider identity alone.
 


### PR DESCRIPTION
## Summary

- Document the DeepSeek direct provider row in AGENTS.md and add a V4 Flash Responses config example to the user guide.
- Add sampler client tests asserting DeepSeek accepts both Chat Completions and Responses backends and rejects Messages.
- Make DeepSeek Responses opaque-history replay explicitly fail closed (`ResponsesDialect::DeepSeek` returns no replay value) with a regression test, keeping provider history isolated.
- Document the `ResponsesDialect::DeepSeek` variant.

## Rebase notes

Rebased onto `main` after `3f83f287` ("feat(deepseek): support V4 Flash Responses API") landed the refined implementation. Conflicts in `default_models.json`, `provider.rs`, `deepseek_models.rs`, `types.rs`, and the provider docs were resolved in favor of `main`'s superset (max output tokens, backend search, curated reasoning menus); this PR now carries only its unique additions. The formatting-only follow-up commit was dropped as already upstream.

## Verification

`cargo fmt --check` clean; `cargo clippy --locked --all-targets` clean for sampling-types, sampler, and shell; full sampling-types + sampler suites green (602 tests); shell DeepSeek tests green (8).