### PR TITLE
Expose remaining opt-in feature flags in Advanced settings

### DIFF
--- a/crates/codegen/xai-grok-pager/src/app/agent_view/mod.rs
+++ b/crates/codegen/xai-grok-pager/src/app/agent_view/mod.rs
@@ -1975,15 +1975,10 @@ fn is_hash_key(key: &KeyEvent) -> bool {
     key.code == KeyCode::Char('#')
         || (key.code == KeyCode::Char('3') && key.modifiers.contains(KeyModifiers::SHIFT))
 }
-/// Check `[features] remember_mode` in config.toml. Defaults to `false`.
+/// Check `[features] remember_mode` via the Advanced local-feature-flag
+/// loader (effective config). Defaults to `false`.
 fn remember_mode_enabled() -> bool {
-    let path = xai_grok_tools::util::grok_home::grok_home().join("config.toml");
-    let Some(doc) = crate::config_toml_edit::read_config_document_for_edit(&path) else {
-        return false;
-    };
-    doc.get("features")
-        .and_then(|f| f.get("remember_mode"))
-        .and_then(|v| v.as_bool())
+    xai_grok_shell::util::config::load_local_feature_flag_sync("features.remember_mode")
         .unwrap_or(false)
 }
 /// Mouse reporting toggle chord (Ctrl+R on scrollback), for unified-log diagnostics.

--- a/crates/codegen/xai-grok-pager/src/settings/defs.rs
+++ b/crates/codegen/xai-grok-pager/src/settings/defs.rs
@@ -2095,7 +2095,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Memory tools",
-            description: "Enable persistent memory tools, /memory, /remember, and /dream.",
+            description: "Turn on cross-session memory so the agent can store and recall notes \
+                          with /memory, /remember, and /dream. Off by default; restart after \
+                          enabling so new sessions load the memory tools.",
             keywords: &["memory", "remember", "dream", "persistent", "tools", "flag"],
             kind: SettingKind::Bool { default: false },
             restart_required: true,
@@ -2106,7 +2108,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Automatic memory dreaming",
-            description: "Allow automatic background memory consolidation when memory is enabled.",
+            description: "When Memory tools are on, periodically consolidate recent sessions \
+                          into durable MEMORY.md notes in the background. Disable if you only \
+                          want manual /remember and /dream.",
             keywords: &["memory", "dream", "automatic", "consolidation", "flag"],
             kind: SettingKind::Bool { default: true },
             restart_required: true,
@@ -2117,9 +2121,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Product telemetry",
-            description: "Opt in to anonymous product-analytics telemetry \
-                          (`[features] telemetry` / GROK_TELEMETRY_ENABLED). \
-                          Separate from coding-data sharing under Privacy.",
+            description: "Send anonymous product-analytics events (feature usage counts, not \
+                          your prompts or code). Separate from Privacy → coding-data sharing. \
+                          Restart required.",
             keywords: &[
                 "telemetry",
                 "analytics",
@@ -2137,7 +2141,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "LSP tools",
-            description: "Enable language-server navigation and code intelligence tools.",
+            description: "Expose language-server tools so the agent can jump to definitions, \
+                          find references, and use other IDE-style code intelligence from \
+                          configured LSP servers. Restart required.",
             keywords: &["lsp", "language server", "definition", "references", "flag"],
             kind: SettingKind::Bool { default: false },
             restart_required: true,
@@ -2148,7 +2154,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Web fetch tool",
-            description: "Enable fetching and reading specific web pages from new sessions.",
+            description: "Let the agent fetch a specific URL and read the page as markdown \
+                          (beyond search snippets). Off by default; applies to new sessions \
+                          after restart.",
             keywords: &["web", "fetch", "url", "research", "tool", "flag"],
             kind: SettingKind::Bool { default: false },
             restart_required: true,
@@ -2159,9 +2167,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Web fetch allow localhost",
-            description: "Allow web_fetch to explicit loopback hosts only \
-                          (localhost / 127.0.0.0/8 / ::1). Private and cloud-metadata \
-                          ranges stay blocked. Requires Web fetch tool.",
+            description: "When Web fetch is on, also allow fetches to explicit loopback hosts \
+                          (localhost, 127.0.0.0/8, ::1) — useful for local docs servers. \
+                          Private LAN and cloud-metadata addresses stay blocked.",
             keywords: &[
                 "web",
                 "fetch",
@@ -2180,7 +2188,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Two-pass compaction",
-            description: "Prefire a background summary before context compaction.",
+            description: "Before context fills up, prefire a background summary of older \
+                          history, then compact NOTE + recent tail when the threshold hits. \
+                          Can improve long-session continuity; restart required.",
             keywords: &["two pass", "compaction", "summary", "context", "flag"],
             kind: SettingKind::Bool { default: false },
             restart_required: true,
@@ -2191,7 +2201,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Non-Git workspace warning",
-            description: "Show a blocking warning when a session starts outside a Git repository.",
+            description: "Show a blocking startup warning when the working directory is not \
+                          a Git repo, so you can quit before losing rewind/hunk tracking that \
+                          depends on Git. Restart required.",
             keywords: &["git", "repository", "workspace", "warning", "flag"],
             kind: SettingKind::Bool { default: false },
             restart_required: true,
@@ -2202,8 +2214,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Remember-mode shortcut",
-            description: "Enable `#` on an empty prompt to enter remember mode \
-                          (same as /remember with no args).",
+            description: "On an empty prompt, press # to enter remember mode and save the next \
+                          line as a memory note (same as /remember with no args). Applies \
+                          immediately; Memory tools still need to be enabled for notes to persist.",
             keywords: &[
                 "remember", "memory", "hash", "#", "shortcut", "mode", "flag",
             ],
@@ -2217,8 +2230,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Doom-loop recovery",
-            description: "Detect repetitive model loops and retry the turn with recovery guidance. \
-                          On by default; turn off to disable recovery retries.",
+            description: "When the model repeats the same failing tool pattern, inject recovery \
+                          guidance and retry the turn instead of spinning. On by default; turn \
+                          off only if you want raw unassisted retries. Restart required.",
             keywords: &["doom loop", "repetition", "recovery", "retry", "flag"],
             kind: SettingKind::Bool { default: true },
             restart_required: true,
@@ -2229,7 +2243,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Subagent worktree snapshots",
-            description: "Store completed isolated subagent worktrees as durable Git refs.",
+            description: "After an isolated subagent finishes, snapshot its worktree into a \
+                          durable Git ref and remove the temp directory so you can resume later \
+                          without keeping every worktree on disk. Restart required.",
             keywords: &[
                 "subagent", "worktree", "snapshot", "git ref", "resume", "flag",
             ],
@@ -2242,7 +2258,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Crash handler",
-            description: "Install the opt-in crash handler for richer panic/crash reports.",
+            description: "Install a richer crash/panic handler that captures stack traces and \
+                          restores the terminal more reliably after a hard failure. Off by \
+                          default; restart required to install.",
             keywords: &["crash", "handler", "panic", "diagnostics", "flag"],
             kind: SettingKind::Bool { default: false },
             restart_required: true,
@@ -2253,8 +2271,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Mouse reporting toggle",
-            description: "Enable Ctrl+R (scrollback) and /toggle-mouse-reporting to flip \
-                          terminal mouse capture for native click-drag copy/paste.",
+            description: "Register Ctrl+R (scrollback focused) and /toggle-mouse-reporting so you \
+                          can turn terminal mouse capture off for native click-drag copy/paste, \
+                          then turn TUI mouse features back on. Restart required.",
             keywords: &[
                 "mouse",
                 "reporting",
@@ -2274,7 +2293,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Shell command suggestions",
-            description: "Enable the shell command suggestion pipeline (history/path completions).",
+            description: "While typing shell/bash-style input, show inline suggestions from \
+                          command history and path completion. Distinct from Appearance → \
+                          Prompt suggestions. Restart required.",
             keywords: &[
                 "suggestions",
                 "shell",
@@ -2292,8 +2313,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "AI shell suggestions",
-            description: "Allow AI-backed shell command suggestions when shell suggestions \
-                          are enabled.",
+            description: "When Shell command suggestions are on, also ask a small model for \
+                          command completions. Uses extra tokens; leave off if you only want \
+                          history/path matches. Restart required.",
             keywords: &["suggestions", "ai", "shell", "completion", "flag"],
             kind: SettingKind::Bool { default: false },
             restart_required: true,
@@ -2304,7 +2326,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Sandbox auto-allow bash",
-            description: "Skip bash permission prompts when an OS sandbox profile is active.",
+            description: "When an OS sandbox profile is active, auto-approve bash tool calls \
+                          that the sandbox already confines — fewer permission prompts, still \
+                          blocked outside the sandbox. Restart required.",
             keywords: &["sandbox", "bash", "auto", "allow", "permissions", "flag"],
             kind: SettingKind::Bool { default: false },
             restart_required: true,
@@ -2315,7 +2339,9 @@ pub fn default_settings() -> Vec<SettingMeta> {
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Respect .gitignore in tools",
-            description: "Make search and file tools skip gitignored paths by default.",
+            description: "Make search, find, and other file tools skip paths listed in \
+                          .gitignore by default (build artifacts, node_modules, etc.). \
+                          Restart required.",
             keywords: &["gitignore", "tools", "search", "ignore", "flag"],
             kind: SettingKind::Bool { default: false },
             restart_required: true,

--- a/crates/codegen/xai-grok-pager/src/settings/defs.rs
+++ b/crates/codegen/xai-grok-pager/src/settings/defs.rs
@@ -7,9 +7,9 @@
 use super::registry::{
     DynamicEnumSource, EnumChoice, SettingCategory, SettingKind, SettingMeta, SettingOwner,
 };
-use crate::appearance::permission_cursor::DefaultSelectedPermission;
 use crate::appearance::ScrollMode;
 use crate::appearance::TextSelection;
+use crate::appearance::permission_cursor::DefaultSelectedPermission;
 
 use xai_grok_shell::agent::config::UiConfig;
 use xai_grok_tools::implementations::grok_build::ask_user_question;
@@ -110,8 +110,7 @@ const PERMISSION_MODE_CHOICES: &[EnumChoice] = &[
     EnumChoice {
         canonical: "auto",
         display: "Auto",
-        description:
-            "LLM classifier approves safe tools; dangerous actions may still prompt or deny.",
+        description: "LLM classifier approves safe tools; dangerous actions may still prompt or deny.",
     },
     EnumChoice {
         canonical: "always-approve",
@@ -369,8 +368,7 @@ const VOICE_CAPTURE_MODE_CHOICES: &[EnumChoice] = &[
     EnumChoice {
         canonical: "hold",
         display: "Hold to talk",
-        description:
-            "Hold Ctrl+Space / F8 to record, release to stop. Needs a Kitty-protocol terminal.",
+        description: "Hold Ctrl+Space / F8 to record, release to stop. Needs a Kitty-protocol terminal.",
     },
 ];
 
@@ -390,8 +388,7 @@ const VOICE_STT_LANGUAGE_CHOICES: &[EnumChoice] = &[
     EnumChoice {
         canonical: "auto",
         display: "System",
-        description:
-            "Use the system locale when it is a supported STT language; otherwise English.",
+        description: "Use the system locale when it is a supported STT language; otherwise English.",
     },
     EnumChoice {
         canonical: "ar",
@@ -2116,6 +2113,26 @@ pub fn default_settings() -> Vec<SettingMeta> {
             hidden_in_minimal: false,
         },
         SettingMeta {
+            key: "features.telemetry",
+            category: SettingCategory::Advanced,
+            owner: SettingOwner::Shell,
+            label: "Product telemetry",
+            description: "Opt in to anonymous product-analytics telemetry \
+                          (`[features] telemetry` / GROK_TELEMETRY_ENABLED). \
+                          Separate from coding-data sharing under Privacy.",
+            keywords: &[
+                "telemetry",
+                "analytics",
+                "metrics",
+                "product",
+                "usage",
+                "flag",
+            ],
+            kind: SettingKind::Bool { default: false },
+            restart_required: true,
+            hidden_in_minimal: false,
+        },
+        SettingMeta {
             key: "features.lsp_tools",
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
@@ -2133,6 +2150,27 @@ pub fn default_settings() -> Vec<SettingMeta> {
             label: "Web fetch tool",
             description: "Enable fetching and reading specific web pages from new sessions.",
             keywords: &["web", "fetch", "url", "research", "tool", "flag"],
+            kind: SettingKind::Bool { default: false },
+            restart_required: true,
+            hidden_in_minimal: false,
+        },
+        SettingMeta {
+            key: "toolset.web_fetch.allow_local",
+            category: SettingCategory::Advanced,
+            owner: SettingOwner::Shell,
+            label: "Web fetch allow localhost",
+            description: "Allow web_fetch to explicit loopback hosts only \
+                          (localhost / 127.0.0.0/8 / ::1). Private and cloud-metadata \
+                          ranges stay blocked. Requires Web fetch tool.",
+            keywords: &[
+                "web",
+                "fetch",
+                "localhost",
+                "loopback",
+                "ssrf",
+                "local",
+                "flag",
+            ],
             kind: SettingKind::Bool { default: false },
             restart_required: true,
             hidden_in_minimal: false,
@@ -2160,13 +2198,29 @@ pub fn default_settings() -> Vec<SettingMeta> {
             hidden_in_minimal: false,
         },
         SettingMeta {
+            key: "features.remember_mode",
+            category: SettingCategory::Advanced,
+            owner: SettingOwner::Shell,
+            label: "Remember-mode shortcut",
+            description: "Enable `#` on an empty prompt to enter remember mode \
+                          (same as /remember with no args).",
+            keywords: &[
+                "remember", "memory", "hash", "#", "shortcut", "mode", "flag",
+            ],
+            kind: SettingKind::Bool { default: false },
+            // Gated by a live config.toml read on each `#` keypress.
+            restart_required: false,
+            hidden_in_minimal: false,
+        },
+        SettingMeta {
             key: "doom_loop_recovery.enabled",
             category: SettingCategory::Advanced,
             owner: SettingOwner::Shell,
             label: "Doom-loop recovery",
-            description: "Detect repetitive model loops and retry the turn with recovery guidance.",
+            description: "Detect repetitive model loops and retry the turn with recovery guidance. \
+                          On by default; turn off to disable recovery retries.",
             keywords: &["doom loop", "repetition", "recovery", "retry", "flag"],
-            kind: SettingKind::Bool { default: false },
+            kind: SettingKind::Bool { default: true },
             restart_required: true,
             hidden_in_minimal: false,
         },
@@ -2179,6 +2233,90 @@ pub fn default_settings() -> Vec<SettingMeta> {
             keywords: &[
                 "subagent", "worktree", "snapshot", "git ref", "resume", "flag",
             ],
+            kind: SettingKind::Bool { default: false },
+            restart_required: true,
+            hidden_in_minimal: false,
+        },
+        SettingMeta {
+            key: "diagnostics.crash_handler",
+            category: SettingCategory::Advanced,
+            owner: SettingOwner::Shell,
+            label: "Crash handler",
+            description: "Install the opt-in crash handler for richer panic/crash reports.",
+            keywords: &["crash", "handler", "panic", "diagnostics", "flag"],
+            kind: SettingKind::Bool { default: false },
+            restart_required: true,
+            hidden_in_minimal: false,
+        },
+        SettingMeta {
+            key: "ui.mouse_reporting_toggle",
+            category: SettingCategory::Advanced,
+            owner: SettingOwner::Shell,
+            label: "Mouse reporting toggle",
+            description: "Enable Ctrl+R (scrollback) and /toggle-mouse-reporting to flip \
+                          terminal mouse capture for native click-drag copy/paste.",
+            keywords: &[
+                "mouse",
+                "reporting",
+                "toggle",
+                "ctrl+r",
+                "capture",
+                "copy",
+                "paste",
+                "flag",
+            ],
+            kind: SettingKind::Bool { default: false },
+            restart_required: true,
+            hidden_in_minimal: false,
+        },
+        SettingMeta {
+            key: "suggestions.enabled",
+            category: SettingCategory::Advanced,
+            owner: SettingOwner::Shell,
+            label: "Shell command suggestions",
+            description: "Enable the shell command suggestion pipeline (history/path completions).",
+            keywords: &[
+                "suggestions",
+                "shell",
+                "completion",
+                "history",
+                "path",
+                "flag",
+            ],
+            kind: SettingKind::Bool { default: false },
+            restart_required: true,
+            hidden_in_minimal: false,
+        },
+        SettingMeta {
+            key: "suggestions.ai_enabled",
+            category: SettingCategory::Advanced,
+            owner: SettingOwner::Shell,
+            label: "AI shell suggestions",
+            description: "Allow AI-backed shell command suggestions when shell suggestions \
+                          are enabled.",
+            keywords: &["suggestions", "ai", "shell", "completion", "flag"],
+            kind: SettingKind::Bool { default: false },
+            restart_required: true,
+            hidden_in_minimal: false,
+        },
+        SettingMeta {
+            key: "sandbox.auto_allow_bash",
+            category: SettingCategory::Advanced,
+            owner: SettingOwner::Shell,
+            label: "Sandbox auto-allow bash",
+            description: "Skip bash permission prompts when an OS sandbox profile is active.",
+            keywords: &["sandbox", "bash", "auto", "allow", "permissions", "flag"],
+            kind: SettingKind::Bool { default: false },
+            restart_required: true,
+            hidden_in_minimal: false,
+        },
+        SettingMeta {
+            key: "tools.respect_gitignore",
+            category: SettingCategory::Advanced,
+            owner: SettingOwner::Shell,
+            label: "Respect .gitignore in tools",
+            description: "Make search and file tools skip gitignored paths by default.",
+            keywords: &["gitignore", "tools", "search", "ignore", "flag"],
             kind: SettingKind::Bool { default: false },
             restart_required: true,
             hidden_in_minimal: false,

--- a/crates/codegen/xai-grok-pager/src/views/settings_modal/render.rs
+++ b/crates/codegen/xai-grok-pager/src/views/settings_modal/render.rs
@@ -632,7 +632,15 @@ pub(super) fn render_rows(
                 };
                 let value_opt = values.get(row_pos).and_then(|v| v.as_ref());
                 let is_selected = row_idx == state.selected;
-                let is_expanded = expanded_snapshot.contains(key);
+                let is_hovered = hover_row_snapshot == Some(row_idx);
+                // Feature-flag rows surface context on select/hover so users
+                // don't have to discover Right/`▸`. Other rows stay expand-on-demand.
+                let is_expanded = description_visible(
+                    key,
+                    expanded_snapshot.contains(key),
+                    is_selected,
+                    is_hovered,
+                );
 
                 // Group rows carry no scalar value; render a chevron row that
                 // opens the sub-sheet (skips the value/edited machinery below).
@@ -640,7 +648,6 @@ pub(super) fn render_rows(
                     meta.kind,
                     SettingKind::Group { .. } | SettingKind::DynamicMultiSelect { .. }
                 ) {
-                    let is_hovered = hover_row_snapshot == Some(row_idx);
                     let value_rect = render_setting_group_row(
                         buf,
                         label_rect,
@@ -715,7 +722,6 @@ pub(super) fn render_rows(
                 // Hit-rect spans both lines for two-line rows.
                 state.row_rects[row_idx] = render_area;
 
-                let is_hovered = hover_row_snapshot == Some(row_idx);
                 // `DynamicEnum` values persist canonicals. Render the resolved
                 // display label while retaining the canonical in modal state.
                 let rendered_value = match value {
@@ -838,12 +844,20 @@ fn compute_filtered_row_heights(state: &SettingsModalState, area_width: u16) -> 
                 };
                 // Group rows carry no value; height = chevron row + the expanded
                 // description (cap 8), agreeing with the forward render loop.
+                let is_selected = row_idx == state.selected;
+                let is_hovered = state.hover_row == Some(row_idx);
+                let is_expanded = description_visible(
+                    key,
+                    state.expanded_keys.contains(key),
+                    is_selected,
+                    is_hovered,
+                );
                 if matches!(
                     meta.kind,
                     SettingKind::Group { .. } | SettingKind::DynamicMultiSelect { .. }
                 ) {
                     let mut h: u16 = 1;
-                    if state.expanded_keys.contains(key) {
+                    if is_expanded {
                         h = h.saturating_add(wrapped_description_height(meta, None, area_width, 8));
                     }
                     heights.push(h);
@@ -853,7 +867,6 @@ fn compute_filtered_row_heights(state: &SettingsModalState, area_width: u16) -> 
                     heights.push(1);
                     continue;
                 };
-                let is_expanded = state.expanded_keys.contains(key);
                 let lock = state.row_lock(key);
                 let value_display = value_display(meta, &value, lock, &state.pager_snapshot);
                 let show_restart_pill = meta.restart_required && is_expanded;
@@ -2725,6 +2738,21 @@ pub(super) fn render_setting_row(
             }
         }
     }
+}
+
+/// Whether a setting row should paint its description.
+///
+/// Explicit Right/`▸` expansion always wins. Advanced local feature flags also
+/// surface their description while selected or hovered so opt-in flags explain
+/// themselves without discovering the expand chord.
+fn description_visible(
+    key: crate::settings::SettingKey,
+    explicitly_expanded: bool,
+    is_selected: bool,
+    is_hovered: bool,
+) -> bool {
+    explicitly_expanded
+        || (crate::settings::is_local_feature_flag(key) && (is_selected || is_hovered))
 }
 
 /// Render the wrapped description for an expanded row.

--- a/crates/codegen/xai-grok-pager/src/views/settings_modal/render.rs
+++ b/crates/codegen/xai-grok-pager/src/views/settings_modal/render.rs
@@ -3113,3 +3113,37 @@ pub(super) fn build_shortcuts(state: &SettingsModalState) -> Vec<Shortcut<'stati
         ],
     }
 }
+
+#[cfg(test)]
+mod description_visible_tests {
+    use super::description_visible;
+
+    #[test]
+    fn ordinary_settings_need_explicit_expand() {
+        assert!(!description_visible("compact_mode", false, true, true));
+        assert!(description_visible("compact_mode", true, false, false));
+    }
+
+    #[test]
+    fn local_feature_flags_show_on_select_or_hover() {
+        assert!(description_visible(
+            "features.web_fetch",
+            false,
+            true,
+            false
+        ));
+        assert!(description_visible(
+            "features.telemetry",
+            false,
+            false,
+            true
+        ));
+        assert!(!description_visible(
+            "features.web_fetch",
+            false,
+            false,
+            false
+        ));
+        assert!(description_visible("memory.enabled", true, false, false));
+    }
+}

--- a/crates/codegen/xai-grok-shell/src/util/config/settings_writes.rs
+++ b/crates/codegen/xai-grok-shell/src/util/config/settings_writes.rs
@@ -23,11 +23,19 @@ pub const LOCAL_FEATURE_FLAG_SPECS: &[LocalFeatureFlagSpec] = &[
         default: true,
     },
     LocalFeatureFlagSpec {
+        key: "features.telemetry",
+        default: false,
+    },
+    LocalFeatureFlagSpec {
         key: "features.lsp_tools",
         default: false,
     },
     LocalFeatureFlagSpec {
         key: "features.web_fetch",
+        default: false,
+    },
+    LocalFeatureFlagSpec {
+        key: "toolset.web_fetch.allow_local",
         default: false,
     },
     LocalFeatureFlagSpec {
@@ -39,11 +47,40 @@ pub const LOCAL_FEATURE_FLAG_SPECS: &[LocalFeatureFlagSpec] = &[
         default: false,
     },
     LocalFeatureFlagSpec {
-        key: "doom_loop_recovery.enabled",
+        key: "features.remember_mode",
         default: false,
     },
     LocalFeatureFlagSpec {
+        // Matches `Config::resolve_doom_loop_recovery` default ON.
+        key: "doom_loop_recovery.enabled",
+        default: true,
+    },
+    LocalFeatureFlagSpec {
         key: "features.subagent_worktree_snapshot",
+        default: false,
+    },
+    LocalFeatureFlagSpec {
+        key: "diagnostics.crash_handler",
+        default: false,
+    },
+    LocalFeatureFlagSpec {
+        key: "ui.mouse_reporting_toggle",
+        default: false,
+    },
+    LocalFeatureFlagSpec {
+        key: "suggestions.enabled",
+        default: false,
+    },
+    LocalFeatureFlagSpec {
+        key: "suggestions.ai_enabled",
+        default: false,
+    },
+    LocalFeatureFlagSpec {
+        key: "sandbox.auto_allow_bash",
+        default: false,
+    },
+    LocalFeatureFlagSpec {
+        key: "tools.respect_gitignore",
         default: false,
     },
 ];
@@ -56,9 +93,25 @@ pub fn local_feature_flag_default(key: &str) -> Option<bool> {
 }
 
 fn read_nested_bool(root: &TomlValue, key: &str) -> Option<bool> {
-    key.split('.')
-        .try_fold(root, |value, part| value.get(part))
-        .and_then(TomlValue::as_bool)
+    let value = key
+        .split('.')
+        .try_fold(root, |value, part| value.get(part))?;
+    if let Some(b) = value.as_bool() {
+        return Some(b);
+    }
+    // `[features] telemetry` also accepts TelemetryMode string forms
+    // (`true`/`false`/`session_metrics`). Treat any non-disabled mode as on
+    // so the Advanced bool toggle reflects the effective gate.
+    if key == "features.telemetry" {
+        return value
+            .as_str()
+            .and_then(|raw| match raw.trim().to_ascii_lowercase().as_str() {
+                "true" | "1" | "enabled" | "on" | "session_metrics" => Some(true),
+                "false" | "0" | "disabled" | "off" => Some(false),
+                _ => None,
+            });
+    }
+    None
 }
 
 pub fn load_local_feature_flag_sync(key: &str) -> Option<bool> {
@@ -598,11 +651,19 @@ mod tests {
             Some(true)
         );
         assert_eq!(
+            local_feature_flag_default("features.telemetry"),
+            Some(false)
+        );
+        assert_eq!(
             local_feature_flag_default("features.lsp_tools"),
             Some(false)
         );
         assert_eq!(
             local_feature_flag_default("features.web_fetch"),
+            Some(false)
+        );
+        assert_eq!(
+            local_feature_flag_default("toolset.web_fetch.allow_local"),
             Some(false)
         );
         assert_eq!(
@@ -614,11 +675,39 @@ mod tests {
             Some(false)
         );
         assert_eq!(
-            local_feature_flag_default("doom_loop_recovery.enabled"),
+            local_feature_flag_default("features.remember_mode"),
             Some(false)
         );
         assert_eq!(
+            local_feature_flag_default("doom_loop_recovery.enabled"),
+            Some(true)
+        );
+        assert_eq!(
             local_feature_flag_default("features.subagent_worktree_snapshot"),
+            Some(false)
+        );
+        assert_eq!(
+            local_feature_flag_default("diagnostics.crash_handler"),
+            Some(false)
+        );
+        assert_eq!(
+            local_feature_flag_default("ui.mouse_reporting_toggle"),
+            Some(false)
+        );
+        assert_eq!(
+            local_feature_flag_default("suggestions.enabled"),
+            Some(false)
+        );
+        assert_eq!(
+            local_feature_flag_default("suggestions.ai_enabled"),
+            Some(false)
+        );
+        assert_eq!(
+            local_feature_flag_default("sandbox.auto_allow_bash"),
+            Some(false)
+        );
+        assert_eq!(
+            local_feature_flag_default("tools.respect_gitignore"),
             Some(false)
         );
         assert_eq!(local_feature_flag_default("features.unknown"), None);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Settings → Advanced already had toggles for a subset of default-off / local feature flags (`memory`, `lsp_tools`, `web_fetch`, etc.). Several other user-facing opt-ins were still config.toml / env-only. This PR brings the remaining enableable flags into the same Advanced local-feature-flag path, with clearer descriptions that show on select/hover.

## Added Advanced toggles

| Setting key | Default | Notes |
|---|---|---|
| `features.telemetry` | off | Product analytics master switch |
| `features.remember_mode` | off | `#` empty-prompt remember shortcut (live; no restart) |
| `toolset.web_fetch.allow_local` | off | Loopback-only companion to web_fetch |
| `diagnostics.crash_handler` | off | Opt-in crash handler |
| `ui.mouse_reporting_toggle` | off | Ctrl+R / `/toggle-mouse-reporting` |
| `suggestions.enabled` | off | Shell suggestion pipeline |
| `suggestions.ai_enabled` | off | AI-backed shell suggestions |
| `sandbox.auto_allow_bash` | off | Skip bash prompts when sandboxed |
| `tools.respect_gitignore` | off | Tools skip gitignored paths |

## Descriptions / discoverability

- Every Advanced local feature flag now has a concrete product description (what it does, when to use it, restart notes).
- Those rows **auto-expand their description on select or hover**, so you get context without needing Right / `▸`. Other settings stay expand-on-demand.

## Fixes

- **`doom_loop_recovery.enabled`** settings default was `false` while the runtime resolver defaults **on**. Advanced now shows/defaults to `true` so reset no longer silently disables recovery.
- `remember_mode` gating now reads through the shared local-feature-flag loader (effective config) instead of a raw user-config.toml peek.

## Not added (intentionally)

- Default-**on** kill switches (`image_gen`, `session_recap`, MCP liveness, etc.)
- TodoGate — still CLI/remote only; durable config key is explicitly deferred in `defs.rs`
- Enterprise / remote-only levers (`zdr_access_enabled`, official marketplace auto-register)

## Verification

Focused package tests for `xai-grok-shell` local feature flags + pager settings registry defaults + `description_visible` unit tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4f1e7a0-9c52-4ac0-ae2f-263e2e3fd1a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4f1e7a0-9c52-4ac0-ae2f-263e2e3fd1a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

