### PR TITLE
Show Advanced feature-flag descriptions on select only

### DIFF
--- a/crates/codegen/xai-grok-pager/src/views/settings_modal/render.rs
+++ b/crates/codegen/xai-grok-pager/src/views/settings_modal/render.rs
@@ -633,14 +633,10 @@ pub(super) fn render_rows(
                 let value_opt = values.get(row_pos).and_then(|v| v.as_ref());
                 let is_selected = row_idx == state.selected;
                 let is_hovered = hover_row_snapshot == Some(row_idx);
-                // Feature-flag rows surface context on select/hover so users
-                // don't have to discover Right/`▸`. Other rows stay expand-on-demand.
-                let is_expanded = description_visible(
-                    key,
-                    expanded_snapshot.contains(key),
-                    is_selected,
-                    is_hovered,
-                );
+                // Feature-flag rows surface context when selected (click /
+                // keyboard focus), not on hover. Other rows stay expand-on-demand.
+                let is_expanded =
+                    description_visible(key, expanded_snapshot.contains(key), is_selected);
 
                 // Group rows carry no scalar value; render a chevron row that
                 // opens the sub-sheet (skips the value/edited machinery below).
@@ -845,13 +841,8 @@ fn compute_filtered_row_heights(state: &SettingsModalState, area_width: u16) -> 
                 // Group rows carry no value; height = chevron row + the expanded
                 // description (cap 8), agreeing with the forward render loop.
                 let is_selected = row_idx == state.selected;
-                let is_hovered = state.hover_row == Some(row_idx);
-                let is_expanded = description_visible(
-                    key,
-                    state.expanded_keys.contains(key),
-                    is_selected,
-                    is_hovered,
-                );
+                let is_expanded =
+                    description_visible(key, state.expanded_keys.contains(key), is_selected);
                 if matches!(
                     meta.kind,
                     SettingKind::Group { .. } | SettingKind::DynamicMultiSelect { .. }
@@ -2743,16 +2734,15 @@ pub(super) fn render_setting_row(
 /// Whether a setting row should paint its description.
 ///
 /// Explicit Right/`▸` expansion always wins. Advanced local feature flags also
-/// surface their description while selected or hovered so opt-in flags explain
-/// themselves without discovering the expand chord.
+/// surface their description while selected (click / keyboard focus) so opt-in
+/// flags explain themselves without discovering the expand chord. Hover alone
+/// does not expand — that would thrash layout as the pointer moves.
 fn description_visible(
     key: crate::settings::SettingKey,
     explicitly_expanded: bool,
     is_selected: bool,
-    is_hovered: bool,
 ) -> bool {
-    explicitly_expanded
-        || (crate::settings::is_local_feature_flag(key) && (is_selected || is_hovered))
+    explicitly_expanded || (crate::settings::is_local_feature_flag(key) && is_selected)
 }
 
 /// Render the wrapped description for an expanded row.
@@ -3120,30 +3110,15 @@ mod description_visible_tests {
 
     #[test]
     fn ordinary_settings_need_explicit_expand() {
-        assert!(!description_visible("compact_mode", false, true, true));
-        assert!(description_visible("compact_mode", true, false, false));
+        assert!(!description_visible("compact_mode", false, true));
+        assert!(description_visible("compact_mode", true, false));
     }
 
     #[test]
-    fn local_feature_flags_show_on_select_or_hover() {
-        assert!(description_visible(
-            "features.web_fetch",
-            false,
-            true,
-            false
-        ));
-        assert!(description_visible(
-            "features.telemetry",
-            false,
-            false,
-            true
-        ));
-        assert!(!description_visible(
-            "features.web_fetch",
-            false,
-            false,
-            false
-        ));
-        assert!(description_visible("memory.enabled", true, false, false));
+    fn local_feature_flags_show_on_select_not_hover() {
+        assert!(description_visible("features.web_fetch", false, true));
+        assert!(!description_visible("features.telemetry", false, false));
+        assert!(!description_visible("features.web_fetch", false, false));
+        assert!(description_visible("memory.enabled", true, false));
     }
 }

--- a/docs/releases/v0.1.220-open-grok.53.md
+++ b/docs/releases/v0.1.220-open-grok.53.md
@@ -1,7 +1,8 @@
 # Open Grok v0.1.220-open-grok.53
 
 This release makes remaining opt-in / Advanced feature flags available in
-Settings, with clearer descriptions that show when you select or hover a flag.
+Settings, with clearer descriptions that show when you select (click /
+keyboard-focus) a flag.
 
 ## Settings → Advanced
 
@@ -23,8 +24,9 @@ toggles and get fuller descriptions.
 
 ## Discoverability
 
-- Advanced local feature-flag rows **auto-show their description on select or
-  hover**, so you get context without pressing Right / clicking `▸`.
+- Advanced local feature-flag rows **auto-show their description when selected**
+  (click or keyboard focus), so you get context without pressing Right /
+  clicking `▸`. Hover alone does not expand.
 - Other settings stay expand-on-demand.
 
 ## Fixes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Advanced local feature-flag rows were expanding their descriptions on hover as well as select. Hover caused layout thrash as the pointer moved; descriptions should only appear when the row is clicked / keyboard-focused (or explicitly expanded with Right / `▸`).

## Change

- `description_visible` now keys off selection only for local feature flags
- Hover still highlights the row but does not expand the description
- Unit test updated accordingly
- `.53` release notes wording aligned with the click-only behavior

## Verification

`description_visible` unit tests in `settings_modal/render.rs`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4f1e7a0-9c52-4ac0-ae2f-263e2e3fd1a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4f1e7a0-9c52-4ac0-ae2f-263e2e3fd1a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

