### PR TITLE
Add selectable OpenAI image generation tools

### DIFF
--- a/crates/codegen/xai-grok-config-types/src/lib.rs
+++ b/crates/codegen/xai-grok-config-types/src/lib.rs
@@ -17,6 +17,37 @@ mod pool;
 pub use pool::*;
 use serde::{Deserialize, Serialize};
 use xai_grok_announcements::RemoteAnnouncement;
+
+/// User-selected image generation service.
+///
+/// This is a routing decision only. Each provider keeps its own endpoint,
+/// credentials, headers, and retry path.
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ImageGenerationProvider {
+    #[default]
+    Grok,
+    #[serde(rename = "openai")]
+    OpenAi,
+}
+
+impl ImageGenerationProvider {
+    pub const fn as_canonical(self) -> &'static str {
+        match self {
+            Self::Grok => "grok",
+            Self::OpenAi => "openai",
+        }
+    }
+
+    pub fn from_canonical(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "grok" => Some(Self::Grok),
+            "openai" => Some(Self::OpenAi),
+            _ => None,
+        }
+    }
+}
+
 /// A remote `campaigns[]` entry: an `id` gate plus a full-power
 /// flattened config patch (the JSON sibling of a `[[campaigns]]` TOML override).
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/codegen/xai-grok-pager/docs/user-guide/04-slash-commands.md
+++ b/crates/codegen/xai-grok-pager/docs/user-guide/04-slash-commands.md
@@ -251,6 +251,11 @@ Generate an image from a text description.
 /imagine a golden sunset over a calm ocean with silhouetted palm trees
 ```
 
+Choose **Settings → Models → Image generation** to use either **Grok
+Imagine** or **OpenAI Images** for `/imagine` and image editing. The OpenAI
+option requires `open-grok login --codex`, a supported paid ChatGPT plan, and
+an Open Grok restart after changing the setting.
+
 ### `/imagine-video <description>`
 
 Generate a video from a text (or image) description. It plans shots, generates source images, and animates them with `image_to_video`.

--- a/crates/codegen/xai-grok-pager/docs/user-guide/05-configuration.md
+++ b/crates/codegen/xai-grok-pager/docs/user-guide/05-configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Grok reads settings from config files, environment variables, and CLI flags. This page covers the common options.
+Open Grok reads settings from config files, environment variables, and CLI flags. This page covers the common options.
 
 ---
 
@@ -56,6 +56,8 @@ remember_tool_approvals = false        # show per-command "Always allow" options
                                        # grants are remembered per project (default: false); see 22-permissions-and-safety.md
 code_mode = "direct"                   # "direct", "code_mode" (mixed), or "code_mode_only";
                                        # restart Open Grok after changing this setting
+image_generation_provider = "grok"     # "grok" (Imagine) or "openai" (gpt-image-2 via Codex OAuth);
+                                       # restart Open Grok after changing this setting
 show_thinking_blocks = true            # show agent thinking blocks in the TUI (default: true)
 group_tool_verbs = true                # fold runs of read/search/list tool calls and subagent rows
                                        # — and finished thoughts among them — into one row (default: true)
@@ -110,6 +112,15 @@ Grok after changing the setting; the running process keeps the configuration it
 loaded at startup. An OpenAI Codex catalog entry that explicitly requires
 `code_mode_only` overrides this preference. Non-Responses models remain in
 direct mode.
+
+#### Image generation provider
+
+`[ui] image_generation_provider` controls both `image_gen` and `image_edit`.
+`"grok"` (default) uses xAI Imagine and xAI credentials. `"openai"` uses
+`gpt-image-2` through the Codex Images API and the isolated
+`~/.opengrok/codex-auth.json` credential; run `open-grok login --codex` first.
+Known ChatGPT Free accounts are not eligible. Restart Open Grok after changing
+the setting. Video generation remains xAI-only.
 
 #### Input Mode
 

--- a/crates/codegen/xai-grok-pager/src/app/actions.rs
+++ b/crates/codegen/xai-grok-pager/src/app/actions.rs
@@ -501,6 +501,9 @@ pub enum Action {
     /// Select direct, mixed Code Mode, or Code Mode Only after Open Grok is
     /// restarted. SHELL-owned; persisted to `[ui].code_mode`.
     SetCodeMode(xai_grok_shell::agent::config::ToolModePreference),
+    /// Select Grok Imagine or OpenAI Images for new sessions after Open Grok
+    /// restarts. SHELL-owned; persisted to `[ui].image_generation_provider`.
+    SetImageGenerationProvider(xai_grok_shell::agent::config::ImageGenerationProvider),
     /// Toggle the ask_user_question timeout. SHELL-owned; persisted to
     /// `[toolset.ask_user_question].timeout_enabled`. Applies to new sessions.
     SetAskUserQuestionTimeoutEnabled(bool),
@@ -1281,11 +1284,7 @@ impl PlanModeKind {
     }
     /// Construct from a bool (the inverse of [`Self::to_bool`]).
     pub fn from_bool(b: bool) -> Self {
-        if b {
-            Self::On
-        } else {
-            Self::Off
-        }
+        if b { Self::On } else { Self::Off }
     }
 }
 /// Async side effect produced by [`super::dispatch::dispatch`].

--- a/crates/codegen/xai-grok-pager/src/app/app_view.rs
+++ b/crates/codegen/xai-grok-pager/src/app/app_view.rs
@@ -641,7 +641,8 @@ fn parse_esc_ttl(raw: Option<String>) -> Duration {
 ///
 /// Current set:
 /// - `usage` — coding credit / billing UI (alias: `/cost`)
-/// - `imagine` — image generation entry point
+/// - `imagine` — Grok Imagine entry point (not restricted when the persisted
+///   OpenAI Images route is active)
 /// - `imagine-video` — video generation entry point
 /// - `voice` — voice dictation entry point (the Ctrl+Space / F8 keybinding is
 ///   gated separately in [`crate::app::dispatch::voice`], since it bypasses the
@@ -2161,6 +2162,11 @@ impl AppView {
         let names: Vec<String> = if restricted {
             TIER_RESTRICTED_COMMANDS
                 .iter()
+                .filter(|name| {
+                    !(**name == "imagine"
+                        && self.current_ui.image_generation_provider
+                            == Some(xai_grok_shell::agent::config::ImageGenerationProvider::OpenAi))
+                })
                 .map(|n| (*n).to_string())
                 .collect()
         } else {

--- a/crates/codegen/xai-grok-pager/src/app/dispatch/router.rs
+++ b/crates/codegen/xai-grok-pager/src/app/dispatch/router.rs
@@ -89,15 +89,16 @@ use super::settings::setters::{
     set_contextual_hint_undo, set_contextual_hint_word_select, set_deepseek_api_key,
     set_default_model, set_default_selected_permission, set_display_refresh_auto_cadence,
     set_enter_steers, set_fireworks_api_key, set_fork_secondary_model, set_group_tool_verbs,
-    set_hunk_tracker_mode, set_invert_scroll, set_keep_text_selection, set_kimi_api_endpoint,
-    set_kimi_api_key, set_local_feature_flag, set_max_thoughts_width, set_memory_model,
-    set_multiline_mode, set_opencode_go_api_key, set_opencode_go_enabled_models,
-    set_page_flip_on_send, set_perplexity_api_key, set_perplexity_web_search,
-    set_prompt_suggestions, set_recap_model, set_remember_tool_approvals, set_render_mermaid,
-    set_respect_manual_folds, set_screen_mode, set_scroll_lines, set_scroll_mode, set_scroll_speed,
-    set_show_thinking_blocks, set_show_tips, set_simple_mode, set_theme, set_timeline,
-    set_timestamps, set_vim_mode, set_voice_capture_mode, set_voice_keybind_enabled,
-    set_voice_stt_language, set_wafer_api_key, set_web_search_source, set_x_search_enabled,
+    set_hunk_tracker_mode, set_image_generation_provider, set_invert_scroll,
+    set_keep_text_selection, set_kimi_api_endpoint, set_kimi_api_key, set_local_feature_flag,
+    set_max_thoughts_width, set_memory_model, set_multiline_mode, set_opencode_go_api_key,
+    set_opencode_go_enabled_models, set_page_flip_on_send, set_perplexity_api_key,
+    set_perplexity_web_search, set_prompt_suggestions, set_recap_model,
+    set_remember_tool_approvals, set_render_mermaid, set_respect_manual_folds, set_screen_mode,
+    set_scroll_lines, set_scroll_mode, set_scroll_speed, set_show_thinking_blocks, set_show_tips,
+    set_simple_mode, set_theme, set_timeline, set_timestamps, set_vim_mode, set_voice_capture_mode,
+    set_voice_keybind_enabled, set_voice_stt_language, set_wafer_api_key, set_web_search_source,
+    set_x_search_enabled,
 };
 use super::settings::ui::{
     dispatch_confirm_reset_setting, dispatch_open_command_palette,
@@ -1105,6 +1106,7 @@ pub(crate) fn dispatch(action: Action, app: &mut AppView) -> Vec<Effect> {
         Action::SetVimMode(v) => set_vim_mode(app, v),
         Action::SetRememberToolApprovals(v) => set_remember_tool_approvals(app, v),
         Action::SetCodeMode(v) => set_code_mode(app, v),
+        Action::SetImageGenerationProvider(v) => set_image_generation_provider(app, v),
         Action::SetAskUserQuestionTimeoutEnabled(v) => {
             set_ask_user_question_timeout_enabled(app, v)
         }

--- a/crates/codegen/xai-grok-pager/src/app/dispatch/settings/setters.rs
+++ b/crates/codegen/xai-grok-pager/src/app/dispatch/settings/setters.rs
@@ -928,6 +928,38 @@ pub(in crate::app::dispatch) fn set_code_mode(
     }]
 }
 
+pub(super) fn set_image_generation_provider_inner(
+    app: &mut AppView,
+    new: xai_grok_shell::agent::config::ImageGenerationProvider,
+) {
+    app.current_ui.image_generation_provider = Some(new);
+}
+
+pub(in crate::app::dispatch) fn set_image_generation_provider(
+    app: &mut AppView,
+    new: xai_grok_shell::agent::config::ImageGenerationProvider,
+) -> Vec<Effect> {
+    let previous_state = app.current_ui.image_generation_provider;
+    let previous = previous_state.unwrap_or_default();
+    if previous == new && previous_state.is_some() {
+        return vec![];
+    }
+    set_image_generation_provider_inner(app, new);
+    refresh_open_settings_modals(app);
+    let label = match new {
+        xai_grok_shell::agent::config::ImageGenerationProvider::Grok => "Grok Imagine",
+        xai_grok_shell::agent::config::ImageGenerationProvider::OpenAi => "OpenAI Images",
+    };
+    app.show_toast(&format!(
+        "Image generation: {label} (restart Open Grok to apply)"
+    ));
+    vec![Effect::PersistSetting {
+        key: "image_generation_provider",
+        value: crate::settings::SettingValue::Enum(new.as_canonical()),
+        rollback_value: crate::settings::SettingValue::Enum(previous.as_canonical()),
+    }]
+}
+
 /// Mirror the just-written TOML value in `app` so the modal reflects it (the
 /// effective timeout is re-resolved shell-side at agent build).
 pub(super) fn set_ask_user_question_timeout_enabled_inner(app: &mut AppView, new: bool) {

--- a/crates/codegen/xai-grok-pager/src/app/dispatch/settings/ui.rs
+++ b/crates/codegen/xai-grok-pager/src/app/dispatch/settings/ui.rs
@@ -7,14 +7,15 @@ use super::setters::{
     set_compact_mode_inner, set_contextual_hint_inner, set_default_model_inner,
     set_default_selected_permission_inner, set_display_refresh_auto_cadence_inner,
     set_enter_steers_inner, set_fork_secondary_model_inner, set_group_tool_verbs_inner,
-    set_hunk_tracker_mode_inner, set_invert_scroll_inner, set_keep_text_selection_inner,
-    set_max_thoughts_width_inner, set_memory_model_inner, set_multiline_mode,
-    set_page_flip_on_send_inner, set_prompt_suggestions_inner, set_recap_model_inner,
-    set_remember_tool_approvals_inner, set_render_mermaid_inner, set_respect_manual_folds_inner,
-    set_screen_mode_inner, set_scroll_lines_inner, set_scroll_mode_inner, set_scroll_speed_inner,
-    set_show_thinking_blocks_inner, set_show_tips_inner, set_simple_mode_inner, set_theme_inner,
-    set_timeline_inner, set_timestamps, set_timestamps_inner, set_vim_mode_inner,
-    set_voice_capture_mode_inner, set_voice_keybind_enabled_inner, set_voice_stt_language_inner,
+    set_hunk_tracker_mode_inner, set_image_generation_provider_inner, set_invert_scroll_inner,
+    set_keep_text_selection_inner, set_max_thoughts_width_inner, set_memory_model_inner,
+    set_multiline_mode, set_page_flip_on_send_inner, set_prompt_suggestions_inner,
+    set_recap_model_inner, set_remember_tool_approvals_inner, set_render_mermaid_inner,
+    set_respect_manual_folds_inner, set_screen_mode_inner, set_scroll_lines_inner,
+    set_scroll_mode_inner, set_scroll_speed_inner, set_show_thinking_blocks_inner,
+    set_show_tips_inner, set_simple_mode_inner, set_theme_inner, set_timeline_inner,
+    set_timestamps, set_timestamps_inner, set_vim_mode_inner, set_voice_capture_mode_inner,
+    set_voice_keybind_enabled_inner, set_voice_stt_language_inner,
 };
 use crate::app::actions::{Action, Effect};
 use crate::app::app_view::{ActiveView, AppView};
@@ -1210,6 +1211,10 @@ pub(in crate::app::dispatch) fn action_for_reset(
             xai_grok_shell::agent::config::ToolModePreference::from_canonical(value)
                 .map(Action::SetCodeMode)
         }
+        ("image_generation_provider", SettingValue::Enum(value)) => {
+            xai_grok_shell::agent::config::ImageGenerationProvider::from_canonical(value)
+                .map(Action::SetImageGenerationProvider)
+        }
         ("toolset.ask_user_question.timeout_enabled", SettingValue::Bool(b)) => {
             Some(Action::SetAskUserQuestionTimeoutEnabled(*b))
         }
@@ -1642,6 +1647,13 @@ pub(in crate::app::dispatch) fn apply_setting_rollback(
                 xai_grok_shell::agent::config::ToolModePreference::from_canonical(value)
             {
                 set_code_mode_inner(app, preference);
+            }
+        }
+        ("image_generation_provider", SettingValue::Enum(value)) => {
+            if let Some(provider) =
+                xai_grok_shell::agent::config::ImageGenerationProvider::from_canonical(value)
+            {
+                set_image_generation_provider_inner(app, provider);
             }
         }
         // ask_user_question timeout: if rollback equals the effective

--- a/crates/codegen/xai-grok-pager/src/app/dispatch/tests/settings.rs
+++ b/crates/codegen/xai-grok-pager/src/app/dispatch/tests/settings.rs
@@ -1344,6 +1344,48 @@ fn code_mode_setter_persists_and_rolls_back_with_restart_toast() {
 }
 
 #[test]
+fn image_generation_provider_persists_and_rolls_back() {
+    use xai_grok_shell::agent::config::ImageGenerationProvider;
+
+    let mut app = test_app_with_agent();
+    let effects = dispatch(
+        Action::SetImageGenerationProvider(ImageGenerationProvider::OpenAi),
+        &mut app,
+    );
+    assert_eq!(
+        app.current_ui.image_generation_provider,
+        Some(ImageGenerationProvider::OpenAi)
+    );
+    assert!(matches!(
+        effects.as_slice(),
+        [Effect::PersistSetting {
+            key: "image_generation_provider",
+            value: crate::settings::SettingValue::Enum("openai"),
+            rollback_value: crate::settings::SettingValue::Enum("grok"),
+        }]
+    ));
+    let toast = app
+        .agents
+        .get(&AgentId(0))
+        .and_then(|agent| agent.toast.as_ref())
+        .map(|(message, _)| message.as_str())
+        .expect("image generation provider setter must show a toast");
+    assert!(toast.contains("OpenAI Images"));
+    assert!(toast.contains("restart Open Grok to apply"));
+
+    let rollback_effects = apply_setting_rollback(
+        &mut app,
+        "image_generation_provider",
+        &crate::settings::SettingValue::Enum("grok"),
+    );
+    assert!(rollback_effects.is_empty());
+    assert_eq!(
+        app.current_ui.image_generation_provider,
+        Some(ImageGenerationProvider::Grok)
+    );
+}
+
+#[test]
 fn local_feature_flag_setter_updates_modal_and_persists() {
     use crate::views::modal::ActiveModal;
 
@@ -1771,6 +1813,14 @@ fn move_setting_away_from_default(app: &mut AppView, key: crate::settings::Setti
         "code_mode" => {
             let _ = dispatch(
                 Action::SetCodeMode(xai_grok_shell::agent::config::ToolModePreference::CodeMode),
+                app,
+            );
+        }
+        "image_generation_provider" => {
+            let _ = dispatch(
+                Action::SetImageGenerationProvider(
+                    xai_grok_shell::agent::config::ImageGenerationProvider::OpenAi,
+                ),
                 app,
             );
         }

--- a/crates/codegen/xai-grok-pager/src/app/dispatch/tests/task_result.rs
+++ b/crates/codegen/xai-grok-pager/src/app/dispatch/tests/task_result.rs
@@ -1966,6 +1966,36 @@ fn successful_model_switch_updates_provider_and_round_trips_xai_access_state() {
 }
 
 #[test]
+fn openai_images_are_not_blocked_by_xai_free_tier() {
+    let mut app = test_app_with_agent();
+    app.primary_provider = PrimaryProvider::Xai;
+    app.subscription_tier = Some("Free".to_owned());
+    app.current_ui.image_generation_provider =
+        Some(xai_grok_shell::agent::config::ImageGenerationProvider::OpenAi);
+
+    app.apply_tier_restrictions();
+
+    assert!(
+        !app.tier_restricted_commands
+            .iter()
+            .any(|name| name == "imagine"),
+        "OpenAI Images uses Codex entitlement, not the xAI image tier",
+    );
+    assert!(
+        app.tier_restricted_commands
+            .iter()
+            .any(|name| name == "imagine-video"),
+        "video generation remains xAI-only",
+    );
+    assert!(
+        app.tier_restricted_commands
+            .iter()
+            .any(|name| name == "voice"),
+        "unrelated xAI tier restrictions must remain active",
+    );
+}
+
+#[test]
 fn provider_transition_fans_usage_visibility_into_existing_slash_surfaces() {
     let mut app = test_app_with_agent();
     let id = AgentId(0);

--- a/crates/codegen/xai-grok-pager/src/app/effects/helpers.rs
+++ b/crates/codegen/xai-grok-pager/src/app/effects/helpers.rs
@@ -1306,6 +1306,25 @@ pub(crate) async fn persist_setting(
                 .await
                 .map_err(|e| e.to_string())
         }
+        "image_generation_provider" => {
+            let SettingValue::Enum(value) = value else {
+                return Err(kind_mismatch(
+                    "image_generation_provider",
+                    "Enum",
+                    &value,
+                ));
+            };
+            let provider =
+                xai_grok_shell::agent::config::ImageGenerationProvider::from_canonical(value)
+                    .ok_or_else(|| {
+                        format!(
+                            "persist_setting(image_generation_provider) unknown value: {value}"
+                        )
+                    })?;
+            xai_grok_shell::util::config::set_image_generation_provider(provider)
+                .await
+                .map_err(|e| e.to_string())
+        }
         "toolset.ask_user_question.timeout_enabled" => {
             let SettingValue::Bool(b) = value else {
                 return Err(

--- a/crates/codegen/xai-grok-pager/src/app/effects/tests.rs
+++ b/crates/codegen/xai-grok-pager/src/app/effects/tests.rs
@@ -858,6 +858,30 @@ async fn persist_setting_rejects_unknown_code_mode_choice() {
 }
 
 #[tokio::test]
+async fn persist_setting_rejects_unknown_image_generation_provider() {
+    use crate::settings::SettingValue;
+    let error = persist_setting(
+        "image_generation_provider",
+        SettingValue::Enum("automatic"),
+    )
+    .await
+    .expect_err("unknown image providers must fail closed");
+    assert!(error.contains("unknown value: automatic"));
+}
+
+#[tokio::test]
+async fn persist_setting_type_mismatch_errors_image_generation_provider() {
+    use crate::settings::SettingValue;
+    let error = persist_setting(
+        "image_generation_provider",
+        SettingValue::String("openai".to_owned()),
+    )
+    .await
+    .expect_err("image generation provider requires an Enum payload");
+    assert!(error.contains("persist_setting(image_generation_provider) expected Enum"));
+}
+
+#[tokio::test]
 async fn persist_setting_type_mismatch_errors_auxiliary_models() {
     use crate::settings::SettingValue;
     for key in ["recap_model", "memory_model"] {

--- a/crates/codegen/xai-grok-pager/src/settings/defs.rs
+++ b/crates/codegen/xai-grok-pager/src/settings/defs.rs
@@ -137,6 +137,19 @@ const CODE_MODE_CHOICES: &[EnumChoice] = &[
     },
 ];
 
+const IMAGE_GENERATION_PROVIDER_CHOICES: &[EnumChoice] = &[
+    EnumChoice {
+        canonical: "grok",
+        display: "Grok Imagine",
+        description: "Use xAI Imagine with isolated xAI credentials.",
+    },
+    EnumChoice {
+        canonical: "openai",
+        display: "OpenAI Images",
+        description: "Use gpt-image-2 through the Codex Images API and isolated ChatGPT Codex credentials.",
+    },
+];
+
 // ---------------------------------------------------------------------------
 // Coding-data-sharing catalog.
 //
@@ -1010,6 +1023,36 @@ pub fn default_settings() -> Vec<SettingMeta> {
             kind: SettingKind::Enum {
                 default: ui_default.code_mode.unwrap_or_default().as_canonical(),
                 choices: CODE_MODE_CHOICES,
+                supports_preview: false,
+            },
+            restart_required: true,
+            hidden_in_minimal: false,
+        },
+        // SHELL-owned `[ui].image_generation_provider`. Tool clients and auth
+        // routes are fixed when the process builds its session harnesses.
+        SettingMeta {
+            key: "image_generation_provider",
+            category: SettingCategory::Models,
+            owner: SettingOwner::Shell,
+            label: "Image generation",
+            description: "Choose Grok Imagine or OpenAI Images for image generation and editing. OpenAI Images requires `open-grok login --codex` and a supported paid ChatGPT plan. Restart Open Grok to apply.",
+            keywords: &[
+                "image",
+                "generation",
+                "edit",
+                "imagine",
+                "grok",
+                "xai",
+                "openai",
+                "codex",
+                "gpt-image-2",
+            ],
+            kind: SettingKind::Enum {
+                default: ui_default
+                    .image_generation_provider
+                    .unwrap_or_default()
+                    .as_canonical(),
+                choices: IMAGE_GENERATION_PROVIDER_CHOICES,
                 supports_preview: false,
             },
             restart_required: true,

--- a/crates/codegen/xai-grok-pager/src/settings/registry.rs
+++ b/crates/codegen/xai-grok-pager/src/settings/registry.rs
@@ -846,6 +846,11 @@ pub fn current_value_for(
         "code_mode" => Some(SettingValue::Enum(
             ui.code_mode.unwrap_or_default().as_canonical(),
         )),
+        "image_generation_provider" => Some(SettingValue::Enum(
+            ui.image_generation_provider
+                .unwrap_or_default()
+                .as_canonical(),
+        )),
         // ask_user_question timeout: reflects the effective TOML merge; the
         // toggle writes the user layer, and env/remote settings tiers feed the
         // final gate at agent build. None → the resolver-shared default (ON).
@@ -1313,6 +1318,28 @@ mod tests {
                             .map(|choice| choice.canonical)
                             .collect::<Vec<_>>(),
                         vec!["direct", "code_mode", "code_mode_only"],
+                    );
+                }
+                (
+                    "image_generation_provider",
+                    SettingKind::Enum {
+                        default, choices, ..
+                    },
+                ) => {
+                    assert_eq!(
+                        *default,
+                        ui.image_generation_provider
+                            .unwrap_or_default()
+                            .as_canonical(),
+                        "image_generation_provider default drifts from UiConfig::default()",
+                    );
+                    assert_eq!(*default, "grok");
+                    assert_eq!(
+                        choices
+                            .iter()
+                            .map(|choice| choice.canonical)
+                            .collect::<Vec<_>>(),
+                        vec!["grok", "openai"],
                     );
                 }
                 // ask_user_question timeout: no UiConfig mirror (lives under

--- a/crates/codegen/xai-grok-pager/src/views/settings_modal/state.rs
+++ b/crates/codegen/xai-grok-pager/src/views/settings_modal/state.rs
@@ -7,9 +7,9 @@ use ratatui::layout::Rect;
 use crate::app::actions::Action;
 use crate::input::line_editor::LineEditor;
 use crate::settings::{
-    current_value_for, dynamic_enum_choices, dynamic_multi_select_choices, CodingDataSharingLock,
-    EnumChoice, OwnedEnumChoice, PagerLocalSnapshot, SecretInput, SettingCategory, SettingKey,
-    SettingKind, SettingMeta, SettingValue, SettingsRegistry, StringValidator,
+    CodingDataSharingLock, EnumChoice, OwnedEnumChoice, PagerLocalSnapshot, SecretInput,
+    SettingCategory, SettingKey, SettingKind, SettingMeta, SettingValue, SettingsRegistry,
+    StringValidator, current_value_for, dynamic_enum_choices, dynamic_multi_select_choices,
 };
 use crate::views::modal_window::ModalWindowState;
 
@@ -1153,6 +1153,10 @@ pub(super) fn action_for_enum_commit(key: SettingKey, choice: &'static str) -> O
         },
         "code_mode" => xai_grok_shell::agent::config::ToolModePreference::from_canonical(choice)
             .map(Action::SetCodeMode),
+        "image_generation_provider" => {
+            xai_grok_shell::agent::config::ImageGenerationProvider::from_canonical(choice)
+                .map(Action::SetImageGenerationProvider)
+        }
         "hunk_tracker_mode" => Some(Action::SetHunkTrackerMode(choice.to_string())),
         "screen_mode" => Some(Action::SetScreenMode(choice.to_string())),
         "kimi_api_endpoint" => Some(Action::SetKimiApiEndpoint(choice.to_string())),

--- a/crates/codegen/xai-grok-pager/src/views/settings_modal/tests.rs
+++ b/crates/codegen/xai-grok-pager/src/views/settings_modal/tests.rs
@@ -896,6 +896,8 @@ fn rows_contain_categories_and_settings_through_pr_14() {
             "plan_mode",
             // SHELL-owned coding_data_sharing (Privacy category).
             "coding_data_sharing",
+            // SHELL-owned image provider (Models category, restart-required).
+            "image_generation_provider",
             // SHELL-owned default_model (Models category).
             "default_model",
             // Kimi service selector and isolated credentials.

--- a/crates/codegen/xai-grok-pager/tests/settings_e2e.rs
+++ b/crates/codegen/xai-grok-pager/tests/settings_e2e.rs
@@ -16,8 +16,8 @@ use xai_grok_pager::settings::{
     SettingValue, SettingsRegistry,
 };
 use xai_grok_pager::views::settings_modal::{
-    handle_settings_key, handle_settings_mouse, RowEntry, SettingsEntryPoint, SettingsKeyOutcome,
-    SettingsModalMode, SettingsModalState,
+    RowEntry, SettingsEntryPoint, SettingsKeyOutcome, SettingsModalMode, SettingsModalState,
+    handle_settings_key, handle_settings_mouse,
 };
 use xai_grok_shell::agent::config::UiConfig;
 
@@ -40,6 +40,7 @@ const ALL_SETTINGS_EXERCISED: &[&str] = &[
     "vim_mode",
     "remember_tool_approvals",
     "code_mode",
+    "image_generation_provider",
     "toolset.ask_user_question.timeout_enabled",
     "keep_text_selection",
     "theme",
@@ -554,6 +555,57 @@ fn code_mode_registry_contract_is_restart_required_and_direct_by_default() {
 }
 
 #[test]
+fn enter_on_image_generation_provider_commits_openai() {
+    let mut state = make_state();
+    navigate_to(&mut state, "image_generation_provider");
+    assert!(matches!(
+        handle_settings_key(&mut state, &press(KeyCode::Enter)),
+        SettingsKeyOutcome::Changed
+    ));
+    assert!(matches!(
+        state.mode(),
+        SettingsModalMode::PickingEnum {
+            key: "image_generation_provider",
+            choices_idx: 0,
+            supports_preview: false,
+            original_value: SettingValue::Enum("grok"),
+        }
+    ));
+    assert!(matches!(
+        handle_settings_key(&mut state, &press(KeyCode::Down)),
+        SettingsKeyOutcome::Changed
+    ));
+    assert!(matches!(
+        handle_settings_key(&mut state, &press(KeyCode::Enter)),
+        SettingsKeyOutcome::Action(Action::SetImageGenerationProvider(
+            xai_grok_shell::agent::config::ImageGenerationProvider::OpenAi
+        ))
+    ));
+}
+
+#[test]
+fn image_generation_provider_registry_contract() {
+    let registry = SettingsRegistry::defaults();
+    let meta = registry
+        .find("image_generation_provider")
+        .expect("image generation provider must be registered");
+    assert_eq!(meta.label, "Image generation");
+    assert_eq!(meta.category, SettingCategory::Models);
+    assert_eq!(meta.owner, SettingOwner::Shell);
+    assert!(meta.restart_required);
+    assert!(matches!(
+        meta.kind,
+        SettingKind::Enum {
+            default: "grok",
+            supports_preview: false,
+            ..
+        }
+    ));
+    assert!(meta.description.contains("OpenAI Images"));
+    assert!(meta.description.contains("login --codex"));
+}
+
+#[test]
 fn enter_on_kimi_service_opens_picker_and_commits_code() {
     let mut s = make_state();
     navigate_to(&mut s, "kimi_api_endpoint");
@@ -1019,6 +1071,29 @@ fn mouse_click_on_code_mode_indicator_opens_picker_in_one_click() {
         s.mode(),
         SettingsModalMode::PickingEnum {
             key: "code_mode",
+            choices_idx: 0,
+            supports_preview: false,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn mouse_click_on_image_generation_provider_opens_picker() {
+    let mut state = make_state();
+    synth_rects(&mut state);
+    let row_y = row_idx_for(&state, "image_generation_provider") as u16;
+    let outcome = handle_settings_mouse(
+        &mut state,
+        MouseEventKind::Down(crossterm::event::MouseButton::Left),
+        72,
+        row_y,
+    );
+    assert!(matches!(outcome, SettingsKeyOutcome::Changed));
+    assert!(matches!(
+        state.mode(),
+        SettingsModalMode::PickingEnum {
+            key: "image_generation_provider",
             choices_idx: 0,
             supports_preview: false,
             ..
@@ -2251,6 +2326,7 @@ fn registry_kind_membership_through_pr_14() {
             "coding_data_sharing",
             "default_selected_permission",
             "hunk_tracker_mode",
+            "image_generation_provider",
             "keep_text_selection",
             "kimi_api_endpoint",
             "permission_mode",
@@ -2346,6 +2422,7 @@ fn enum_settings_membership_through_pr_14() {
             "coding_data_sharing",
             "default_selected_permission",
             "hunk_tracker_mode",
+            "image_generation_provider",
             "keep_text_selection",
             "kimi_api_endpoint",
             "permission_mode",
@@ -2370,7 +2447,7 @@ fn enum_settings_membership_through_pr_14() {
 /// `UiConfig::default()` with independently hard-coded expectations.
 #[test]
 fn defaults_round_trip_through_registry() {
-    use xai_grok_pager::settings::{current_value_for, SettingValue};
+    use xai_grok_pager::settings::{SettingValue, current_value_for};
     let reg = SettingsRegistry::defaults();
     let ui = UiConfig::default();
     let pager = PagerLocalSnapshot::default();
@@ -2408,6 +2485,7 @@ fn defaults_round_trip_through_registry() {
             "vim_mode" => SettingValue::Bool(false),
             "remember_tool_approvals" => SettingValue::Bool(false),
             "code_mode" => SettingValue::Enum("direct"),
+            "image_generation_provider" => SettingValue::Enum("grok"),
             "toolset.ask_user_question.timeout_enabled" => SettingValue::Bool(true),
             "keep_text_selection" => SettingValue::Enum("flash"),
             "theme" => SettingValue::Enum("groknight"),
@@ -4649,7 +4727,7 @@ fn reset_confirm_overlay_renders_prompt_with_setting_label_and_default() {
 #[test]
 fn reset_confirm_prompt_helper_builds_well_formed_string_for_every_setting() {
     use xai_grok_pager::settings::{PagerLocalSnapshot, SettingsRegistry};
-    use xai_grok_pager::views::modal::{reset_confirm_prompt, ActiveModal, ModalConfirmation};
+    use xai_grok_pager::views::modal::{ActiveModal, ModalConfirmation, reset_confirm_prompt};
     use xai_grok_shell::agent::config::UiConfig;
     let reg = SettingsRegistry::defaults();
     for meta in reg.all() {

--- a/crates/codegen/xai-grok-shared/src/ui_config.rs
+++ b/crates/codegen/xai-grok-shared/src/ui_config.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use xai_grok_config_types::DisplayRefreshSettings;
 
+pub use xai_grok_config_types::ImageGenerationProvider;
+
 /// User-selected tool presentation for Responses-backed sessions.
 ///
 /// The custom deserializer preserves compatibility with the original boolean
@@ -189,6 +191,11 @@ pub struct UiConfig {
     /// `true` = mixed Code Mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub code_mode: Option<ToolModePreference>,
+    /// Image generation service for new sessions. Grok uses xAI Imagine with
+    /// xAI credentials. OpenAI uses the Codex Images API with isolated Codex
+    /// OAuth credentials.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_generation_provider: Option<ImageGenerationProvider>,
     /// In-app drag selection highlight: `flash` | `hold` (legacy bool accepted).
     #[serde(
         default,
@@ -354,6 +361,7 @@ impl Default for UiConfig {
             mouse_reporting_toggle: None,
             remember_tool_approvals: None,
             code_mode: None,
+            image_generation_provider: None,
             cancel_subagents_on_turn_cancel: None,
             keep_text_selection: None,
             selection_highlight_duration_ms: None,
@@ -464,6 +472,25 @@ mod tests {
         let error = serde_json::from_str::<UiConfig>(r#"{"code_mode":"automatic"}"#)
             .expect_err("unknown code mode must not silently become direct");
         assert!(error.to_string().contains("unknown variant"));
+    }
+
+    #[test]
+    fn image_generation_provider_defaults_to_grok_and_round_trips() {
+        assert_eq!(UiConfig::default().image_generation_provider, None);
+
+        let openai: UiConfig =
+            serde_json::from_str(r#"{"image_generation_provider":"openai"}"#).unwrap();
+        assert_eq!(
+            openai.image_generation_provider,
+            Some(ImageGenerationProvider::OpenAi)
+        );
+        assert_eq!(
+            serde_json::to_value(openai)
+                .unwrap()
+                .get("image_generation_provider")
+                .and_then(serde_json::Value::as_str),
+            Some("openai")
+        );
     }
 
     #[test]

--- a/crates/codegen/xai-grok-shell/skills/imagine/SKILL.md
+++ b/crates/codegen/xai-grok-shell/skills/imagine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: imagine
 description: >
-  How to use the image_gen and image_edit tool calls in Grok Build: when to
+  How to use the image_gen and image_edit tool calls in Open Grok: when to
   build a visual with code instead of generating it, prompt-craft,
   reference-first handling of real people, factual grounding, and
   asset-consistency. Load this whenever generating or editing an image is on the
@@ -9,17 +9,19 @@ description: >
   to be made. Tool-usage-driven, not triggered by a user merely mentioning
   images.
 metadata:
-  short-description: "Prompting and workflow guidance for Imagine image tools"
+  short-description: "Prompting and workflow guidance for image tools"
 ---
 
-# Imagine
+# Image Generation
 
-Guidance for the two image tool calls in Grok Build:
+Guidance for Open Grok's two provider-routed image tool calls:
 
 - `image_gen` - generate a **new** image from a text prompt.
 - `image_edit` - modify an **existing** image using a text prompt and source image.
 
 Apply this whenever you're considering or about to call either tool.
+The user chooses Grok Imagine or OpenAI Images in Settings; use the same tool
+names and do not assume or expose provider credentials.
 
 ## Build accurate visuals with code, not the image tools
 

--- a/crates/codegen/xai-grok-shell/src/agent/config.rs
+++ b/crates/codegen/xai-grok-shell/src/agent/config.rs
@@ -1784,7 +1784,9 @@ fn resolve_subagent_permission_mode(
 pub use xai_grok_agent::config::AgentDefinition;
 pub use xai_grok_agent::config::Effort;
 pub use xai_grok_agent::config::PermissionMode;
-pub use xai_grok_shared::ui_config::{ContextualHints, ToolModePreference, UiConfig};
+pub use xai_grok_shared::ui_config::{
+    ContextualHints, ImageGenerationProvider, ToolModePreference, UiConfig,
+};
 /// Configuration for selecting the agent definition.
 ///
 /// Set in `config.toml` under `[agent]`:

--- a/crates/codegen/xai-grok-shell/src/agent/mvp_agent/agent_ops.rs
+++ b/crates/codegen/xai-grok-shell/src/agent/mvp_agent/agent_ops.rs
@@ -2233,6 +2233,55 @@ impl MvpAgent {
         &self,
     ) -> xai_grok_tools::implementations::grok_build::image_gen::ImageGenConfig {
         use xai_grok_tools::implementations::grok_build::image_gen::ImageGenConfig;
+        use xai_grok_config_types::ImageGenerationProvider;
+
+        let provider = self
+            .cfg
+            .borrow()
+            .ui
+            .image_generation_provider
+            .unwrap_or_default();
+        if provider == ImageGenerationProvider::OpenAi {
+            let credentials = match crate::codex_auth::load_credentials() {
+                Ok(Some(credentials)) if credentials.supports_image_generation() => credentials,
+                Ok(Some(_)) => {
+                    tracing::info!(
+                        "OpenAI image generation disabled for ChatGPT Free account"
+                    );
+                    return ImageGenConfig::Disabled;
+                }
+                Ok(None) => return ImageGenConfig::Disabled,
+                Err(error) => {
+                    tracing::warn!(%error, "failed to load isolated Codex image credentials");
+                    return ImageGenConfig::Disabled;
+                }
+            };
+            let cfg = self.cfg.borrow();
+            let mut headers = indexmap::IndexMap::new();
+            headers.insert(
+                "originator".to_owned(),
+                crate::codex_auth::CODEX_ORIGINATOR.to_owned(),
+            );
+            if let Some(account_id) = credentials.account_id.as_deref() {
+                headers.insert("ChatGPT-Account-ID".to_owned(), account_id.to_owned());
+            }
+            if credentials.account_is_fedramp {
+                headers.insert("X-OpenAI-Fedramp".to_owned(), "true".to_owned());
+            }
+            return ImageGenConfig::Enabled {
+                provider,
+                api_key: credentials.access_token.clone(),
+                base_url: crate::codex_auth::inference_base_url(),
+                extra_headers: headers,
+                api_key_provider: Some(crate::codex_auth::image_api_key_provider(&credentials)),
+                image_gen_enabled: cfg.resolve_image_gen().value,
+                image_edit_enabled: cfg.resolve_image_edit().value,
+                model_override: None,
+                edit_model_override: None,
+                tier_restricted: false,
+            };
+        }
+
         let Some(api_key) = self.xai_media_api_key() else {
             return ImageGenConfig::Disabled;
         };
@@ -2253,9 +2302,11 @@ impl MvpAgent {
             &base_url,
         );
         ImageGenConfig::Enabled {
+            provider,
             api_key,
             base_url,
             extra_headers: headers,
+            api_key_provider: None,
             image_gen_enabled: cfg.resolve_image_gen().value,
             image_edit_enabled: cfg.resolve_image_edit().value,
             model_override: cfg.resolve_image_gen_model_override(),

--- a/crates/codegen/xai-grok-shell/src/agent/mvp_agent/tests.rs
+++ b/crates/codegen/xai-grok-shell/src/agent/mvp_agent/tests.rs
@@ -3048,6 +3048,80 @@ async fn prepare_image_gen_config_sends_client_identifier_header() {
          applies the coding ZDR opt-out to Build traffic"
     );
 }
+
+#[tokio::test(flavor = "current_thread")]
+#[serial_test::serial]
+async fn prepare_image_gen_config_routes_openai_through_isolated_codex_auth() {
+    use base64::Engine as _;
+    use xai_grok_config_types::ImageGenerationProvider;
+    use xai_grok_test_support::EnvGuard;
+    use xai_grok_tools::implementations::grok_build::image_gen::ImageGenConfig;
+
+    let home = tempfile::tempdir().unwrap();
+    let _env = EnvGuard::set("OPENGROK_HOME", home.path());
+    let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{}");
+    let claims = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+        serde_json::to_vec(&serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "account-123",
+                "chatgpt_plan_type": "plus"
+            }
+        }))
+        .unwrap(),
+    );
+    let id_token = format!("{header}.{claims}.signature");
+    std::fs::write(
+        home.path().join(crate::codex_auth::CODEX_AUTH_FILE_NAME),
+        serde_json::to_vec(&crate::codex_auth::CodexAuthStore {
+            auth_mode: Some("chatgpt".to_owned()),
+            openai_api_key: None,
+            tokens: Some(crate::codex_auth::CodexTokenData {
+                id_token,
+                access_token: "codex-image-token".to_owned(),
+                refresh_token: "refresh".to_owned(),
+                account_id: Some("account-123".to_owned()),
+            }),
+            last_refresh: None,
+        })
+        .unwrap(),
+    )
+    .unwrap();
+
+    let agent = build_minimal_agent_for_tests();
+    agent.cfg.borrow_mut().ui.image_generation_provider =
+        Some(ImageGenerationProvider::OpenAi);
+    let ImageGenConfig::Enabled {
+        provider,
+        api_key,
+        base_url,
+        extra_headers,
+        api_key_provider,
+        tier_restricted,
+        ..
+    } = agent.prepare_image_gen_config()
+    else {
+        panic!("expected OpenAI image generation to be enabled");
+    };
+    assert_eq!(provider, ImageGenerationProvider::OpenAi);
+    assert_eq!(api_key, "codex-image-token");
+    assert_eq!(base_url, crate::codex_auth::inference_base_url());
+    assert_eq!(
+        extra_headers.get("ChatGPT-Account-ID").map(String::as_str),
+        Some("account-123")
+    );
+    assert_eq!(
+        extra_headers.get("originator").map(String::as_str),
+        Some(crate::codex_auth::CODEX_ORIGINATOR)
+    );
+    assert_eq!(
+        api_key_provider
+            .expect("OpenAI image route must keep a live Codex bearer")
+            .current_api_key(),
+        Some("codex-image-token".to_owned())
+    );
+    assert!(!tier_restricted);
+}
+
 /// Same contract for video generation (also a direct API call).
 #[tokio::test(flavor = "current_thread")]
 async fn prepare_video_gen_config_sends_client_identifier_header() {

--- a/crates/codegen/xai-grok-shell/src/codex_auth.rs
+++ b/crates/codegen/xai-grok-shell/src/codex_auth.rs
@@ -211,6 +211,16 @@ impl CodexCredentials {
             is_workspace_account: self.is_workspace_account,
         }
     }
+
+    /// Codex's image-generation extension is unavailable to ChatGPT Free
+    /// accounts. Unknown future plan labels fail open and remain subject to the
+    /// server's authoritative entitlement check.
+    pub(crate) fn supports_image_generation(&self) -> bool {
+        !self
+            .plan_type
+            .as_deref()
+            .is_some_and(|plan| plan.eq_ignore_ascii_case("free"))
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1373,6 +1383,27 @@ impl xai_grok_sampler::BearerResolver for CodexBearerResolver {
     }
 }
 
+/// Adapter for tool clients that need the same identity-anchored Codex bearer
+/// as the sampler without depending on the sampler's richer auth trait.
+#[derive(Debug)]
+struct CodexImageApiKeyProvider {
+    resolver: CodexBearerResolver,
+}
+
+impl xai_grok_tools::types::ApiKeyProvider for CodexImageApiKeyProvider {
+    fn current_api_key(&self) -> Option<String> {
+        xai_grok_sampler::BearerResolver::current_bearer(&self.resolver)
+    }
+}
+
+pub(crate) fn image_api_key_provider(
+    credentials: &CodexCredentials,
+) -> xai_grok_tools::types::SharedApiKeyProvider {
+    Arc::new(CodexImageApiKeyProvider {
+        resolver: CodexBearerResolver::from_credentials(Some(credentials)),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1383,6 +1414,23 @@ mod tests {
         let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
             .encode(serde_json::to_vec(&payload).unwrap());
         format!("{header}.{payload}.signature")
+    }
+
+    #[test]
+    fn image_generation_rejects_only_explicit_free_plan() {
+        let credentials = |plan_type: Option<&str>| CodexCredentials {
+            access_token: "token".to_owned(),
+            account_id: Some("account".to_owned()),
+            chatgpt_user_id: Some("user".to_owned()),
+            email: None,
+            plan_type: plan_type.map(str::to_owned),
+            is_workspace_account: false,
+            account_is_fedramp: false,
+        };
+        assert!(!credentials(Some("free")).supports_image_generation());
+        assert!(!credentials(Some("FREE")).supports_image_generation());
+        assert!(credentials(Some("plus")).supports_image_generation());
+        assert!(credentials(None).supports_image_generation());
     }
 
     fn endpoints(issuer: &str) -> CodexEndpoints {

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_impl/sampler_turn.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_impl/sampler_turn.rs
@@ -202,11 +202,43 @@ fn is_loopback_base_url(url: &str) -> bool {
     }
 }
 
+fn image_tool_allowed_for_provider(
+    image_provider: Option<xai_grok_config_types::ImageGenerationProvider>,
+    active_provider: xai_grok_sampling_types::ModelProvider,
+) -> bool {
+    match image_provider {
+        Some(xai_grok_config_types::ImageGenerationProvider::OpenAi) => true,
+        Some(xai_grok_config_types::ImageGenerationProvider::Grok) => {
+            active_provider.profile().allows_xai_services()
+        }
+        None => false,
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum TurnAuthRefreshRoute {
     CodexOAuth,
     XaiSession,
     ConfigApiKey,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum ToolAuthRefreshRoute {
+    XaiSession,
+    CodexOAuth,
+}
+
+fn tool_auth_refresh_route_for_provider(
+    tool_name: &str,
+    image_provider: Option<xai_grok_config_types::ImageGenerationProvider>,
+) -> ToolAuthRefreshRoute {
+    if matches!(tool_name, "image_gen" | "image_edit")
+        && image_provider == Some(xai_grok_config_types::ImageGenerationProvider::OpenAi)
+    {
+        ToolAuthRefreshRoute::CodexOAuth
+    } else {
+        ToolAuthRefreshRoute::XaiSession
+    }
 }
 
 pub(super) fn turn_auth_refresh_route(
@@ -232,11 +264,12 @@ pub(super) fn turn_auth_refresh_route(
         }
     }
 }
-/// Run a tool call; on an auth-shaped failure, attempt recovery via
-/// `AuthManager` and one retry. When `shared_recovery` is `Some`, concurrent
-/// 401s in the same batch deduplicate via `OnceCell::get_or_init`.
+/// Run a tool call; on an auth-shaped failure, attempt one provider-specific
+/// refresh and one retry. When `shared_recovery` is `Some`, concurrent 401s in
+/// the same provider partition deduplicate via `OnceCell::get_or_init`.
 pub(super) async fn call_with_auth_retry<F, Fut>(
     auth_manager: Option<&std::sync::Arc<crate::auth::AuthManager>>,
+    refresh_route: ToolAuthRefreshRoute,
     shared_recovery: Option<&tokio::sync::OnceCell<bool>>,
     tool_name: &str,
     mut call: F,
@@ -255,13 +288,23 @@ where
     if !is_auth_tool_error(err) {
         return result;
     }
-    let Some(am) = auth_manager else {
-        return result;
+    let recover = || async {
+        match refresh_route {
+            ToolAuthRefreshRoute::XaiSession => {
+                let Some(am) = auth_manager else {
+                    return false;
+                };
+                am.try_recover_unauthorized(crate::auth::recovery::RecoverySource::Background)
+                    .await
+            }
+            ToolAuthRefreshRoute::CodexOAuth => {
+                matches!(crate::codex_auth::force_refresh().await, Ok(Some(_)))
+            }
+        }
     };
-    let src = crate::auth::recovery::RecoverySource::Background;
     let recovered = match shared_recovery {
-        Some(cell) => *cell.get_or_init(|| am.try_recover_unauthorized(src)).await,
-        None => am.try_recover_unauthorized(src).await,
+        Some(cell) => *cell.get_or_init(recover).await,
+        None => recover().await,
     };
     if recovered {
         tracing::info!(
@@ -385,10 +428,17 @@ impl SessionActor {
         .ok()
     }
 
-    /// Keep provider-specific local tools out of Codex requests and Code Mode
-    /// dispatch. Search may cross providers only through an explicit
-    /// non-default model route; xAI media tools have no equivalent explicit
-    /// provider-neutral opt-in and stay xAI-only.
+    pub(super) fn tool_auth_refresh_route(&self, tool_name: &str) -> ToolAuthRefreshRoute {
+        tool_auth_refresh_route_for_provider(
+            tool_name,
+            self.rebuild_spec.image_gen_config.provider(),
+        )
+    }
+
+    /// Keep provider-specific local tools out of incompatible requests and
+    /// Code Mode dispatch. Selecting OpenAI Images is an explicit
+    /// cross-provider opt-in backed by isolated Codex credentials; the default
+    /// Grok Imagine route remains xAI-only.
     pub(crate) fn local_tool_allowed_for_provider(
         &self,
         tool_name: &str,
@@ -404,11 +454,17 @@ impl SessionActor {
             // two never coexist on one request.
             return !provider.profile().allows_xai_services();
         }
+        if matches!(tool_name, "image_gen" | "image_edit") {
+            return image_tool_allowed_for_provider(
+                self.rebuild_spec.image_gen_config.provider(),
+                provider,
+            );
+        }
         if provider.profile().allows_xai_services() {
             return true;
         }
         match tool_name {
-            "image_gen" | "image_edit" | "image_to_video" | "reference_to_video" => false,
+            "image_to_video" | "reference_to_video" => false,
             // Memory storage and FTS are local/provider-neutral. Semantic
             // search may independently use the user's connected xAI embedding
             // route while chat runs through Codex.
@@ -2160,6 +2216,58 @@ impl SessionActor {
 
 fn session_codex_multi_agent_v2(model_supports_policy: bool, session_policy_enabled: bool) -> bool {
     model_supports_policy && session_policy_enabled
+}
+
+#[cfg(test)]
+mod image_tool_provider_tests {
+    use super::{
+        ToolAuthRefreshRoute, image_tool_allowed_for_provider, tool_auth_refresh_route_for_provider,
+    };
+    use xai_grok_config_types::ImageGenerationProvider;
+    use xai_grok_sampling_types::ModelProvider;
+
+    #[test]
+    fn grok_stays_xai_only_while_openai_is_explicitly_cross_provider() {
+        assert!(image_tool_allowed_for_provider(
+            Some(ImageGenerationProvider::Grok),
+            ModelProvider::Xai,
+        ));
+        assert!(!image_tool_allowed_for_provider(
+            Some(ImageGenerationProvider::Grok),
+            ModelProvider::Codex,
+        ));
+        assert!(image_tool_allowed_for_provider(
+            Some(ImageGenerationProvider::OpenAi),
+            ModelProvider::Codex,
+        ));
+        assert!(image_tool_allowed_for_provider(
+            Some(ImageGenerationProvider::OpenAi),
+            ModelProvider::Xai,
+        ));
+        assert!(!image_tool_allowed_for_provider(None, ModelProvider::Xai));
+    }
+
+    #[test]
+    fn openai_image_401s_refresh_only_codex_auth() {
+        assert_eq!(
+            tool_auth_refresh_route_for_provider(
+                "image_gen",
+                Some(ImageGenerationProvider::OpenAi),
+            ),
+            ToolAuthRefreshRoute::CodexOAuth,
+        );
+        assert_eq!(
+            tool_auth_refresh_route_for_provider("image_edit", Some(ImageGenerationProvider::Grok)),
+            ToolAuthRefreshRoute::XaiSession,
+        );
+        assert_eq!(
+            tool_auth_refresh_route_for_provider(
+                "web_search",
+                Some(ImageGenerationProvider::OpenAi)
+            ),
+            ToolAuthRefreshRoute::XaiSession,
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_impl/tool_calls.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_impl/tool_calls.rs
@@ -560,7 +560,8 @@ impl SessionActor {
             }
             map
         };
-        let shared_recovery = Arc::new(tokio::sync::OnceCell::<bool>::const_new());
+        let shared_xai_recovery = Arc::new(tokio::sync::OnceCell::<bool>::const_new());
+        let shared_codex_recovery = Arc::new(tokio::sync::OnceCell::<bool>::const_new());
         let workspace_ops = self.workspace_ops.clone();
         let pending_interjections = self.pending_interjections.clone();
         let session_id: Arc<str> = Arc::from(&*self.session_info.id.0);
@@ -570,7 +571,11 @@ impl SessionActor {
             .map(|(idx, prepared)| {
                 let prepared = Arc::new(prepared.clone());
                 let am = self.auth_manager.clone();
-                let shared_recovery = Arc::clone(&shared_recovery);
+                let auth_refresh_route = self.tool_auth_refresh_route(&prepared.tool_name);
+                let shared_recovery = match auth_refresh_route {
+                    ToolAuthRefreshRoute::XaiSession => Arc::clone(&shared_xai_recovery),
+                    ToolAuthRefreshRoute::CodexOAuth => Arc::clone(&shared_codex_recovery),
+                };
                 let workspace_ops = workspace_ops.clone();
                 let session_id = session_id.clone();
                 let pending_interjections = pending_interjections.clone();
@@ -601,6 +606,7 @@ impl SessionActor {
                             biased;
                             result = call_with_auth_retry(
                                 am.as_ref(),
+                                auth_refresh_route,
                                 Some(&shared_recovery),
                                 &prepared.tool_name,
                                 run_tool,
@@ -616,6 +622,7 @@ impl SessionActor {
                     } else {
                         call_with_auth_retry(
                             am.as_ref(),
+                            auth_refresh_route,
                             Some(&shared_recovery),
                             &prepared.tool_name,
                             run_tool,
@@ -1068,6 +1075,7 @@ impl SessionActor {
             }
             result = call_with_auth_retry(
                 self.auth_manager.as_ref(),
+                self.tool_auth_refresh_route(&prepared.tool_name),
                 None,
                 &prepared.tool_name,
                 dispatch,

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_impl/turn.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_impl/turn.rs
@@ -815,6 +815,11 @@ impl SessionActor {
             crate::session::placeholder_images::attached_image_references(&user_images)
         };
         self.tool_bridge_handle()
+            .update_resource(xai_grok_tools::types::resources::ImageGenerationTurnId(
+                uuid::Uuid::now_v7().to_string(),
+            ))
+            .await;
+        self.tool_bridge_handle()
             .update_resource(xai_grok_tools::types::resources::AttachedImages(
                 attached_image_refs,
             ))

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_tests/media_gen_auth_retry_tests.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_tests/media_gen_auth_retry_tests.rs
@@ -208,10 +208,16 @@ async fn first_call_succeeds_no_refresh() {
     let am = failing_am();
     let calls = AtomicUsize::new(0);
 
-    let r = call_with_auth_retry(Some(&am), None, "test_tool", || {
-        calls.fetch_add(1, Ordering::SeqCst);
-        async { ok_result("ok") }
-    })
+    let r = call_with_auth_retry(
+        Some(&am),
+        ToolAuthRefreshRoute::XaiSession,
+        None,
+        "test_tool",
+        || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { ok_result("ok") }
+        },
+    )
     .await;
 
     assert!(matches!(r.unwrap().output, ToolOutput::Text(t) if t.text == "ok"));
@@ -223,10 +229,16 @@ async fn non_auth_error_is_returned_without_refresh() {
     let am = succeeding_am();
     let calls = AtomicUsize::new(0);
 
-    let r = call_with_auth_retry(Some(&am), None, "test_tool", || {
-        calls.fetch_add(1, Ordering::SeqCst);
-        async { err("request timed out") }
-    })
+    let r = call_with_auth_retry(
+        Some(&am),
+        ToolAuthRefreshRoute::XaiSession,
+        None,
+        "test_tool",
+        || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { err("request timed out") }
+        },
+    )
     .await;
 
     assert!(r.is_err());
@@ -238,16 +250,22 @@ async fn auth_error_with_successful_refresh_retries() {
     let am = succeeding_am();
     let calls = AtomicUsize::new(0);
 
-    let r = call_with_auth_retry(Some(&am), None, "image_gen", || {
-        let n = calls.fetch_add(1, Ordering::SeqCst);
-        async move {
-            if n == 0 {
-                http_err(401, "Image generation failed with HTTP 401 Unauthorized: x")
-            } else {
-                ok_result("retried-ok")
+    let r = call_with_auth_retry(
+        Some(&am),
+        ToolAuthRefreshRoute::XaiSession,
+        None,
+        "image_gen",
+        || {
+            let n = calls.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if n == 0 {
+                    http_err(401, "Image generation failed with HTTP 401 Unauthorized: x")
+                } else {
+                    ok_result("retried-ok")
+                }
             }
-        }
-    })
+        },
+    )
     .await;
 
     assert!(matches!(r.unwrap().output, ToolOutput::Text(t) if t.text == "retried-ok"));
@@ -259,10 +277,16 @@ async fn auth_error_with_failed_refresh_returns_original_error() {
     let am = failing_am();
     let calls = AtomicUsize::new(0);
 
-    let r = call_with_auth_retry(Some(&am), None, "test_tool", || {
-        calls.fetch_add(1, Ordering::SeqCst);
-        async { err("HTTP 401 Unauthorized") }
-    })
+    let r = call_with_auth_retry(
+        Some(&am),
+        ToolAuthRefreshRoute::XaiSession,
+        None,
+        "test_tool",
+        || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { err("HTTP 401 Unauthorized") }
+        },
+    )
     .await;
 
     assert!(r.unwrap_err().to_string().contains("401"));
@@ -277,10 +301,16 @@ async fn auth_error_with_failed_refresh_returns_original_error() {
 async fn auth_error_without_refresher_returns_original_error() {
     let calls = AtomicUsize::new(0);
 
-    let r = call_with_auth_retry(None, None, "test_tool", || {
-        calls.fetch_add(1, Ordering::SeqCst);
-        async { err("HTTP 401 Unauthorized") }
-    })
+    let r = call_with_auth_retry(
+        None,
+        ToolAuthRefreshRoute::XaiSession,
+        None,
+        "test_tool",
+        || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { err("HTTP 401 Unauthorized") }
+        },
+    )
     .await;
 
     assert!(r.is_err());
@@ -295,10 +325,16 @@ async fn retry_is_bounded_at_one_even_if_retry_also_fails_with_auth() {
     let am = succeeding_am();
     let calls = AtomicUsize::new(0);
 
-    let r = call_with_auth_retry(Some(&am), None, "test_tool", || {
-        calls.fetch_add(1, Ordering::SeqCst);
-        async { http_err(401, "Image generation failed with HTTP 401 Unauthorized: x") }
-    })
+    let r = call_with_auth_retry(
+        Some(&am),
+        ToolAuthRefreshRoute::XaiSession,
+        None,
+        "test_tool",
+        || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            async { http_err(401, "Image generation failed with HTTP 401 Unauthorized: x") }
+        },
+    )
     .await;
 
     assert!(r.is_err());

--- a/crates/codegen/xai-grok-shell/src/util/config/settings_writes.rs
+++ b/crates/codegen/xai-grok-shell/src/util/config/settings_writes.rs
@@ -490,6 +490,13 @@ pub async fn set_code_mode(value: crate::agent::config::ToolModePreference) -> R
     update_config(|cfg| cfg.ui.code_mode = Some(value)).await
 }
 
+/// Persist the restart-required `[ui].image_generation_provider` route.
+pub async fn set_image_generation_provider(
+    value: crate::agent::config::ImageGenerationProvider,
+) -> Result<()> {
+    update_config(|cfg| cfg.ui.image_generation_provider = Some(value)).await
+}
+
 /// Persist `[ui].show_thinking_blocks` via `update_config`.
 pub async fn set_show_thinking_blocks(value: bool) -> Result<()> {
     update_config(|cfg| cfg.ui.show_thinking_blocks = Some(value)).await

--- a/crates/codegen/xai-grok-tools/Cargo.toml
+++ b/crates/codegen/xai-grok-tools/Cargo.toml
@@ -19,6 +19,7 @@ xai-tty-utils = { workspace = true }
 xai-grok-code-mode = { path = "../xai-grok-code-mode" }
 xai-grok-code-mode-protocol = { path = "../xai-grok-code-mode-protocol" }
 xai-grok-config = { path = "../xai-grok-config" }
+xai-grok-config-types = { path = "../xai-grok-config-types" }
 xai-grok-extra-ca = { workspace = true }
 xai-grok-tools-api = { path = "../xai-grok-tools-api" }
 xai-grok-workspace-types = { path = "../xai-grok-workspace-types" }

--- a/crates/codegen/xai-grok-tools/src/implementations/grok_build/image_edit/mod.rs
+++ b/crates/codegen/xai-grok-tools/src/implementations/grok_build/image_edit/mod.rs
@@ -1,5 +1,5 @@
-//! `image_edit` tool — edits or transforms images via the xAI Imagine
-//! `/images/edits` endpoint using one or more reference images.
+//! `image_edit` tool — edits or transforms images via the configured Grok
+//! Imagine or OpenAI Images service using one or more reference images.
 //!
 //! Use cases include likeness preservation, style transfer, subject lock,
 //! remixing, and general image-to-image editing. The model chooses this
@@ -16,13 +16,11 @@ use std::io::Cursor;
 
 use base64::Engine as _;
 use image::ImageReader;
-use reqwest::header::AUTHORIZATION;
 
-use crate::attribution::ToolConsumer;
-use crate::implementations::grok_build::image_gen::{ImageGenClient, ImageGenResponse};
+use crate::implementations::grok_build::image_gen::ImageGenClient;
 use crate::types::output::{MediaGenOutput, ToolOutput};
 use crate::types::requirements::{Expr, ToolRequirement};
-use crate::types::resources::SessionFolder;
+use crate::types::resources::{ImageGenerationTurnId, SessionFolder};
 use crate::types::tool::{ToolKind, ToolNamespace};
 use crate::util::image_compress::{FilterType, ReEncodeParams, re_encode_under_limit};
 
@@ -265,7 +263,7 @@ impl crate::types::tool_metadata::ToolMetadata for ImageEditTool {
     }
 
     fn description_template(&self) -> &str {
-        r##"Edit or transform existing image(s) via the xAI Imagine API; use instead of image_gen for image-to-image work (preserve likeness, transfer style, remix). Returns the saved image's absolute path. When telling the user where it was saved, refer to it by its short session-relative path (e.g. `images/1.jpg`) rather than the absolute path, so it renders as a clickable link that opens the image. Each required `image` is one reference — a user-attachment token (e.g. "[Image #1]"), an absolute filesystem path, or a `data:image/...;base64,...` URL (see the `image` parameter for the resolution order and details)."##
+        r##"Edit or transform existing image(s) via the configured image provider; use instead of image_gen for image-to-image work (preserve likeness, transfer style, remix). Returns the saved image's absolute path. When telling the user where it was saved, refer to it by its short session-relative path (for example `images/1.png`) rather than the absolute path, so it renders as a clickable link that opens the image. Each required `image` is one reference — a user-attachment token (for example "[Image #1]"), an absolute filesystem path, or a `data:image/...;base64,...` URL (see the `image` parameter for the resolution order and details)."##
     }
 
     fn requires_expr(&self) -> Expr<ToolRequirement> {
@@ -319,9 +317,14 @@ impl xai_tool_runtime::Tool for ImageEditTool {
             ));
         }
 
-        let client = {
+        let (client, turn_id) = {
             let res = resources.lock().await;
-            res.require::<ImageGenClient>()?.clone()
+            let client = res.require::<ImageGenClient>()?.clone();
+            let turn_id = res
+                .get::<ImageGenerationTurnId>()
+                .map(|value| value.0.clone())
+                .unwrap_or_else(|| ctx.call_id.as_str().to_owned());
+            (client, turn_id)
         };
 
         // Free / X Basic users are zero-limited on Imagine server-side; return
@@ -349,87 +352,9 @@ impl xai_tool_runtime::Tool for ImageEditTool {
         }
         tracing::info!(count = data_urls.len(), "resolved image references");
 
-        let base = client.base_url().trim_end_matches('/');
-        let url = format!("{base}/images/edits");
-
-        let mut payload = serde_json::json!({
-            "model": client.edit_model(),
-            "prompt": input.prompt,
-            "n": 1,
-            "resolution": "1k",
-            "response_format": "b64_json",
-        });
-
-        // API: single ref → "image" object; multiple → "images" array.
-        // For single-image edits the API auto-detects aspect ratio from the
-        // input image and ignores the `aspect_ratio` field. Only send it
-        // for multi-image edits where the API needs an explicit ratio.
-        let mut imgs: Vec<serde_json::Value> = data_urls
-            .iter()
-            .map(|u| serde_json::json!({ "url": u }))
-            .collect();
-        if imgs.len() == 1 {
-            payload["image"] = imgs.pop().unwrap();
-        } else {
-            payload["images"] = serde_json::Value::Array(imgs);
-            payload["aspect_ratio"] = serde_json::json!(input.aspect_ratio);
-        }
-
-        let sent_bearer = client.current_bearer().await;
-        let mut req = client.http().post(&url).json(&payload);
-        if let Some(ref key) = sent_bearer {
-            req = req.header(AUTHORIZATION, format!("Bearer {key}"));
-        }
-
-        let response = req.send().await.map_err(|e| {
-            xai_tool_runtime::ToolError::invalid_arguments(format!(
-                "Image edit API request failed: {e}"
-            ))
-        })?;
-
-        let status = response.status();
-        if status == reqwest::StatusCode::UNAUTHORIZED {
-            client.record_401_attribution(ToolConsumer::ImageGen, sent_bearer.as_deref());
-        }
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            let truncated: String = body.chars().take(200).collect();
-            tracing::warn!(http_status = %status, "Imagine edit API error: {truncated}");
-            return Err(xai_tool_runtime::ToolError::new(
-                xai_tool_runtime::ToolErrorKind::Custom,
-                format!("Image edit failed with HTTP {status}: {truncated}"),
-            )
-            .with_details(serde_json::json!({"code": "http_failure", "status": status.as_u16()})));
-        }
-
-        let body = response.text().await.map_err(|e| {
-            xai_tool_runtime::ToolError::invalid_arguments(format!(
-                "Failed to read image edit response body: {e}"
-            ))
-        })?;
-
-        let resp_json: ImageGenResponse = serde_json::from_str(&body).map_err(|e| {
-            let preview: String = body.chars().take(500).collect();
-            tracing::warn!("Imagine edit API returned unparseable body: {preview}");
-            xai_tool_runtime::ToolError::invalid_arguments(format!(
-                "Failed to parse image edit response: {e} — body preview: {preview}"
-            ))
-        })?;
-
-        let b64_data = resp_json.b64_data().unwrap_or("");
-        if b64_data.is_empty() {
-            return Err(xai_tool_runtime::ToolError::invalid_arguments(
-                "Image edit returned no image data.",
-            ));
-        }
-
-        let image_bytes = base64::engine::general_purpose::STANDARD
-            .decode(b64_data)
-            .map_err(|e| {
-                xai_tool_runtime::ToolError::invalid_arguments(format!(
-                    "Failed to decode base64 image data: {e}"
-                ))
-            })?;
+        let image_bytes = client
+            .edit(&input.prompt, &data_urls, &input.aspect_ratio, &turn_id)
+            .await?;
 
         let session_folder = {
             let res = resources.lock().await;

--- a/crates/codegen/xai-grok-tools/src/implementations/grok_build/image_gen/mod.rs
+++ b/crates/codegen/xai-grok-tools/src/implementations/grok_build/image_gen/mod.rs
@@ -1,5 +1,6 @@
-//! `image_gen` tool — generates images via the xAI Imagine API and saves
-//! them to the local filesystem so the model can reference them in code
+//! `image_gen` tool — generates images via the configured Grok Imagine or
+//! OpenAI Images service and saves them to the local filesystem so the model
+//! can reference them in code
 //! (e.g. `<img src="images/hero.jpg">`).
 //!
 //! Architecture follows the same pattern as `web_search`:
@@ -17,18 +18,22 @@
 
 use base64::Engine as _;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderValue};
+use xai_grok_config_types::ImageGenerationProvider;
 
 use crate::attribution::{SharedAttributionCallback, ToolConsumer};
 use crate::types::SharedApiKeyProvider;
 
 use crate::types::output::{MediaGenOutput, ToolOutput};
 use crate::types::requirements::{Expr, ToolRequirement};
-use crate::types::resources::SessionFolder;
+use crate::types::resources::{ImageGenerationTurnId, SessionFolder};
 use crate::types::tool::{ToolKind, ToolNamespace};
 
 /// Default Imagine model for `image_gen`. Used unless an explicit
 /// `model_override` is supplied via `ImageGenConfig::Enabled`.
 const XAI_IMAGINE_MODEL: &str = "grok-imagine-image-quality";
+/// Codex's image-generation extension model at the pinned upstream contract.
+const OPENAI_IMAGE_MODEL: &str = "gpt-image-2";
+const CODEX_IMAGE_TURN_ID_HEADER: &str = "x-codex-image-turn-id";
 // Some Imagine models (e.g. `grok-imagine-image`, selectable via `model_override`)
 // expand the prompt then generate, and the proxy buffers
 // the whole image before sending any bytes — so the client may receive nothing
@@ -48,10 +53,12 @@ pub use xai_grok_tools_api::slash_commands::{
 /// SuperGrok upsell modal instead; this covers the natural-language path.
 pub(crate) const TIER_RESTRICTED_UPSELL: &str = "Image generation is a SuperGrok feature and isn't available on the free or X Basic tier. Let the user know they can unlock image and video generation by upgrading to SuperGrok: https://grok.com/supergrok?referrer=grok-build. Do not retry this tool.";
 
-/// HTTP client for xAI Imagine API. Cloned per-request; shares `Arc` state.
+/// HTTP client for the configured image provider. Cloned per-request; shares
+/// `Arc` state.
 #[derive(Clone)]
 pub struct ImageGenClient {
     http: reqwest::Client,
+    provider: ImageGenerationProvider,
     base_url: String,
     /// Imagine model slug used by `generate()`. Selected at construction
     /// from `ImageGenConfig::model_override` (falling back to
@@ -61,6 +68,7 @@ pub struct ImageGenClient {
     edit_model: String,
     writer: super::storage::SessionFileWriter,
     api_key_provider: Option<SharedApiKeyProvider>,
+    require_live_bearer: bool,
     /// Optional 401-attribution hook. Hosts wire this so a 401 from the
     /// Imagine API emits an `auth_401_attribution` event with
     /// `consumer == "ImageGen"` for unified auth-failure telemetry.
@@ -78,9 +86,11 @@ impl ImageGenClient {
         api_key_provider: Option<SharedApiKeyProvider>,
     ) -> Result<Self, xai_tool_runtime::ToolError> {
         let ImageGenConfig::Enabled {
+            provider,
             api_key,
             base_url,
             extra_headers,
+            api_key_provider: config_api_key_provider,
             model_override,
             edit_model_override,
             tier_restricted,
@@ -91,27 +101,41 @@ impl ImageGenClient {
                 "Cannot create ImageGenClient from disabled config",
             ));
         };
-        let model = model_override
-            .clone()
-            .filter(|m| !m.trim().is_empty())
-            .unwrap_or_else(|| XAI_IMAGINE_MODEL.to_owned());
-        let edit_model = edit_model_override
-            .clone()
-            .filter(|m| !m.trim().is_empty())
-            .unwrap_or_else(|| super::image_edit::XAI_IMAGINE_EDIT_MODEL.to_owned());
+        let (model, edit_model, extension) = match provider {
+            ImageGenerationProvider::Grok => (
+                model_override
+                    .clone()
+                    .filter(|m| !m.trim().is_empty())
+                    .unwrap_or_else(|| XAI_IMAGINE_MODEL.to_owned()),
+                edit_model_override
+                    .clone()
+                    .filter(|m| !m.trim().is_empty())
+                    .unwrap_or_else(|| super::image_edit::XAI_IMAGINE_EDIT_MODEL.to_owned()),
+                "jpg",
+            ),
+            ImageGenerationProvider::OpenAi => (
+                OPENAI_IMAGE_MODEL.to_owned(),
+                OPENAI_IMAGE_MODEL.to_owned(),
+                "png",
+            ),
+        };
 
         let mut headers = reqwest::header::HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-        // Always bake the static api_key as the default Authorization header.
-        // The dynamic provider overrides per-request; this is the fallback.
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|e| {
-                xai_tool_runtime::ToolError::invalid_arguments(format!(
-                    "Invalid API key for header: {e}"
-                ))
-            })?,
-        );
+        // OpenAI's identity-anchored live resolver fails closed on logout or
+        // account drift, so it must never fall back to the construction-time
+        // bearer. Static OpenAI test/BYOK configurations and the existing xAI
+        // path retain the baked fallback.
+        if *provider != ImageGenerationProvider::OpenAi || config_api_key_provider.is_none() {
+            headers.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|e| {
+                    xai_tool_runtime::ToolError::invalid_arguments(format!(
+                        "Invalid API key for header: {e}"
+                    ))
+                })?,
+            );
+        }
 
         extra_headers.into_iter().try_for_each(|(key, value)| {
             let header_name =
@@ -144,13 +168,16 @@ impl ImageGenClient {
 
         Ok(Self {
             http,
+            provider: *provider,
             base_url: base_url.clone(),
             model,
             edit_model,
-            writer: super::storage::SessionFileWriter::new(DEFAULT_IMAGE_DIR, "jpg"),
-            api_key_provider,
+            writer: super::storage::SessionFileWriter::new(DEFAULT_IMAGE_DIR, extension),
+            api_key_provider: config_api_key_provider.clone().or(api_key_provider),
+            require_live_bearer: *provider == ImageGenerationProvider::OpenAi
+                && config_api_key_provider.is_some(),
             attribution_callback: None,
-            tier_restricted: *tier_restricted,
+            tier_restricted: *provider == ImageGenerationProvider::Grok && *tier_restricted,
         })
     }
 
@@ -180,12 +207,8 @@ impl ImageGenClient {
         crate::attribution::emit_401(self.attribution_callback.as_ref(), consumer, sent_bearer);
     }
 
-    pub(crate) fn base_url(&self) -> &str {
-        &self.base_url
-    }
-
-    pub(crate) fn http(&self) -> &reqwest::Client {
-        &self.http
+    pub fn provider(&self) -> ImageGenerationProvider {
+        self.provider
     }
 
     pub(crate) fn writer(&self) -> &super::storage::SessionFileWriter {
@@ -200,30 +223,109 @@ impl ImageGenClient {
         &self,
         prompt: &str,
         aspect_ratio: &str,
+        turn_id: &str,
     ) -> Result<Vec<u8>, xai_tool_runtime::ToolError> {
-        let url = format!("{}/images/generations", self.base_url.trim_end_matches('/'));
+        let payload = match self.provider {
+            ImageGenerationProvider::Grok => serde_json::json!({
+                "model": self.model,
+                "prompt": prompt,
+                "n": 1,
+                "aspect_ratio": aspect_ratio,
+                "resolution": "1k",
+                "response_format": "b64_json",
+            }),
+            ImageGenerationProvider::OpenAi => serde_json::json!({
+                "model": self.model,
+                "prompt": prompt,
+                "background": "auto",
+                "quality": "auto",
+                "size": openai_size(aspect_ratio),
+            }),
+        };
+        self.send_image_request("generations", "generation", payload, turn_id)
+            .await
+    }
 
-        let payload = serde_json::json!({
-            "model": self.model,
-            "prompt": prompt,
-            "n": 1,
-            "aspect_ratio": aspect_ratio,
-            "resolution": "1k",
-            "response_format": "b64_json",
-        });
+    pub(crate) async fn edit(
+        &self,
+        prompt: &str,
+        data_urls: &[String],
+        aspect_ratio: &str,
+        turn_id: &str,
+    ) -> Result<Vec<u8>, xai_tool_runtime::ToolError> {
+        if self.provider == ImageGenerationProvider::OpenAi && data_urls.len() > 5 {
+            return Err(xai_tool_runtime::ToolError::invalid_arguments(
+                "OpenAI image editing accepts at most 5 reference images.",
+            ));
+        }
+        let payload = match self.provider {
+            ImageGenerationProvider::Grok => {
+                let mut payload = serde_json::json!({
+                    "model": self.edit_model,
+                    "prompt": prompt,
+                    "n": 1,
+                    "resolution": "1k",
+                    "response_format": "b64_json",
+                });
+                let mut images: Vec<serde_json::Value> = data_urls
+                    .iter()
+                    .map(|url| serde_json::json!({ "url": url }))
+                    .collect();
+                if images.len() == 1 {
+                    payload["image"] = images.pop().expect("one image exists");
+                } else {
+                    payload["images"] = serde_json::Value::Array(images);
+                    payload["aspect_ratio"] = serde_json::json!(aspect_ratio);
+                }
+                payload
+            }
+            ImageGenerationProvider::OpenAi => serde_json::json!({
+                "model": self.edit_model,
+                "prompt": prompt,
+                "background": "auto",
+                "quality": "auto",
+                "size": openai_size(aspect_ratio),
+                "images": data_urls
+                    .iter()
+                    .map(|url| serde_json::json!({ "image_url": url }))
+                    .collect::<Vec<_>>(),
+            }),
+        };
+        self.send_image_request("edits", "edit", payload, turn_id)
+            .await
+    }
+
+    async fn send_image_request(
+        &self,
+        endpoint: &str,
+        operation: &str,
+        payload: serde_json::Value,
+        turn_id: &str,
+    ) -> Result<Vec<u8>, xai_tool_runtime::ToolError> {
+        let url = format!("{}/images/{endpoint}", self.base_url.trim_end_matches('/'));
 
         // Capture the bearer once so the request and the 401-attribution
         // emit see the same value (even if the provider rotates between
         // the send and the response handling).
         let sent_bearer = self.current_bearer().await;
+        if self.require_live_bearer && sent_bearer.is_none() {
+            return Err(xai_tool_runtime::ToolError::new(
+                xai_tool_runtime::ToolErrorKind::Custom,
+                "OpenAI image authentication is unavailable; sign in again with `open-grok login --codex`.",
+            )
+            .with_details(serde_json::json!({"code": "auth_required", "status": 401})));
+        }
         let mut req = self.http.post(&url).json(&payload);
         if let Some(ref key) = sent_bearer {
             req = req.header(AUTHORIZATION, format!("Bearer {key}"));
         }
+        if self.provider == ImageGenerationProvider::OpenAi {
+            req = req.header(CODEX_IMAGE_TURN_ID_HEADER, turn_id);
+        }
 
         let response = req.send().await.map_err(|e| {
             xai_tool_runtime::ToolError::invalid_arguments(format!(
-                "Image generation API request failed: {e}"
+                "Image {operation} API request failed: {e}"
             ))
         })?;
 
@@ -234,34 +336,41 @@ impl ImageGenClient {
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
             let truncated: String = body.chars().take(200).collect();
-            tracing::warn!(http_status = %status, "Imagine API error: {truncated}");
+            tracing::warn!(
+                provider = self.provider.as_canonical(),
+                http_status = %status,
+                "image {operation} API error: {truncated}"
+            );
             return Err(xai_tool_runtime::ToolError::new(
                 xai_tool_runtime::ToolErrorKind::Custom,
-                format!("Image generation failed with HTTP {status}: {truncated}"),
+                format!("Image {operation} failed with HTTP {status}: {truncated}"),
             )
             .with_details(serde_json::json!({"code": "http_failure", "status": status.as_u16()})));
         }
 
         let body = response.text().await.map_err(|e| {
             xai_tool_runtime::ToolError::invalid_arguments(format!(
-                "Failed to read image generation response body: {e}"
+                "Failed to read image {operation} response body: {e}"
             ))
         })?;
 
         let resp_json: ImageGenResponse = serde_json::from_str(&body).map_err(|e| {
             let preview: String = body.chars().take(500).collect();
-            tracing::warn!("Imagine API returned unparseable body: {preview}");
+            tracing::warn!(
+                provider = self.provider.as_canonical(),
+                "image {operation} API returned unparseable body: {preview}"
+            );
             xai_tool_runtime::ToolError::invalid_arguments(format!(
-                "Failed to parse image generation response: {e} — body preview: {preview}"
+                "Failed to parse image {operation} response: {e} — body preview: {preview}"
             ))
         })?;
 
         let b64_data = resp_json.b64_data().unwrap_or("");
 
         if b64_data.is_empty() {
-            return Err(xai_tool_runtime::ToolError::invalid_arguments(
-                "Image generation returned no image data.",
-            ));
+            return Err(xai_tool_runtime::ToolError::invalid_arguments(format!(
+                "Image {operation} returned no image data."
+            )));
         }
 
         base64::engine::general_purpose::STANDARD
@@ -274,15 +383,29 @@ impl ImageGenClient {
     }
 }
 
+fn openai_size(aspect_ratio: &str) -> &'static str {
+    match aspect_ratio.trim() {
+        "16:9" | "3:2" | "4:3" | "2:1" | "19.5:9" | "20:9" => "1536x1024",
+        "9:16" | "2:3" | "3:4" | "1:2" | "9:19.5" | "9:20" => "1024x1536",
+        "1:1" => "1024x1024",
+        _ => "auto",
+    }
+}
+
 /// `Enabled` means credentials are present; each tool has its own gate.
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub enum ImageGenConfig {
     #[default]
     Disabled,
     Enabled {
+        provider: ImageGenerationProvider,
         api_key: String,
         base_url: String,
         extra_headers: indexmap::IndexMap<String, String>,
+        /// Provider-specific live bearer source. OpenAI images use the
+        /// identity-anchored Codex resolver; Grok Imagine uses the xAI auth
+        /// manager. This always wins over the legacy session-wide provider.
+        api_key_provider: Option<SharedApiKeyProvider>,
         image_gen_enabled: bool,
         image_edit_enabled: bool,
         /// Optional Imagine model override for `image_gen`. When `Some(non-empty)`,
@@ -301,6 +424,40 @@ pub enum ImageGenConfig {
     },
 }
 
+impl std::fmt::Debug for ImageGenConfig {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Disabled => formatter.write_str("ImageGenConfig::Disabled"),
+            Self::Enabled {
+                provider,
+                base_url,
+                extra_headers,
+                api_key_provider,
+                image_gen_enabled,
+                image_edit_enabled,
+                model_override,
+                edit_model_override,
+                tier_restricted,
+                ..
+            } => formatter
+                .debug_struct("ImageGenConfig::Enabled")
+                .field("provider", provider)
+                .field("base_url", base_url)
+                .field(
+                    "extra_header_names",
+                    &extra_headers.keys().collect::<Vec<_>>(),
+                )
+                .field("has_live_api_key_provider", &api_key_provider.is_some())
+                .field("image_gen_enabled", image_gen_enabled)
+                .field("image_edit_enabled", image_edit_enabled)
+                .field("model_override", model_override)
+                .field("edit_model_override", edit_model_override)
+                .field("tier_restricted", tier_restricted)
+                .finish_non_exhaustive(),
+        }
+    }
+}
+
 /// Session-id header attached to imagine API requests; matches the header
 /// chat requests already carry.
 pub const SESSION_ID_HEADER: &str = "x-grok-session-id";
@@ -311,10 +468,22 @@ impl ImageGenConfig {
         matches!(self, Self::Enabled { .. })
     }
 
+    pub fn provider(&self) -> Option<ImageGenerationProvider> {
+        match self {
+            Self::Enabled { provider, .. } => Some(*provider),
+            Self::Disabled => None,
+        }
+    }
+
     /// Stamp [`SESSION_ID_HEADER`] onto `extra_headers`. A caller-provided
     /// value is never overwritten. No-op when `Disabled`.
     pub fn stamp_session_id_header(&mut self, session_id: &str) {
-        if let Self::Enabled { extra_headers, .. } = self {
+        if let Self::Enabled {
+            provider: ImageGenerationProvider::Grok,
+            extra_headers,
+            ..
+        } = self
+        {
             extra_headers
                 .entry(SESSION_ID_HEADER.to_string())
                 .or_insert_with(|| session_id.to_string());
@@ -399,7 +568,7 @@ impl crate::types::tool_metadata::ToolMetadata for ImageGenTool {
     }
 
     fn description_template(&self) -> &str {
-        "Generate a new image from a text description using Imagine; returns the saved image's absolute path. When telling the user where it was saved, refer to it by its short session-relative path (e.g. `images/1.jpg`) rather than the absolute path, so it renders as a clickable link that opens the image. To produce multiple images, emit multiple tool calls with distinct prompts."
+        "Generate a new image from a text description using the configured image provider; returns the saved image's absolute path. When telling the user where it was saved, refer to it by its short session-relative path (for example `images/1.png`) rather than the absolute path, so it renders as a clickable link that opens the image. To produce multiple images, emit multiple tool calls with distinct prompts."
     }
 
     fn requires_expr(&self) -> Expr<ToolRequirement> {
@@ -446,9 +615,14 @@ impl xai_tool_runtime::Tool for ImageGenTool {
         use crate::types::tool_metadata::shared_resources;
         let resources = shared_resources(&ctx)?;
 
-        let client = {
+        let (client, turn_id) = {
             let res = resources.lock().await;
-            res.require::<ImageGenClient>()?.clone()
+            let client = res.require::<ImageGenClient>()?.clone();
+            let turn_id = res
+                .get::<ImageGenerationTurnId>()
+                .map(|value| value.0.clone())
+                .unwrap_or_else(|| ctx.call_id.as_str().to_owned());
+            (client, turn_id)
         };
 
         // Free / X Basic users are zero-limited on Imagine server-side; return
@@ -458,7 +632,9 @@ impl xai_tool_runtime::Tool for ImageGenTool {
             return Ok(ToolOutput::Text(TIER_RESTRICTED_UPSELL.into()));
         }
 
-        let image_bytes = client.generate(&input.prompt, &input.aspect_ratio).await?;
+        let image_bytes = client
+            .generate(&input.prompt, &input.aspect_ratio, &turn_id)
+            .await?;
 
         let session_folder = {
             let res = resources.lock().await;
@@ -483,8 +659,29 @@ impl xai_tool_runtime::Tool for ImageGenTool {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::types::tool_metadata::test_ctx_with_call_id;
+    use wiremock::matchers::{body_json, header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn openai_config(base_url: String) -> ImageGenConfig {
+        let mut headers = indexmap::IndexMap::new();
+        headers.insert("originator".to_owned(), "codex_cli_rs".to_owned());
+        ImageGenConfig::Enabled {
+            provider: ImageGenerationProvider::OpenAi,
+            api_key: "codex-token".into(),
+            base_url,
+            extra_headers: headers,
+            api_key_provider: None,
+            image_gen_enabled: true,
+            image_edit_enabled: true,
+            model_override: Some("must-not-cross-providers".into()),
+            edit_model_override: Some("must-not-cross-providers".into()),
+            tier_restricted: true,
+        }
+    }
 
     #[test]
     fn tool_name_and_description() {
@@ -503,11 +700,163 @@ mod tests {
     }
 
     #[test]
+    fn openai_size_maps_supported_orientations() {
+        assert_eq!(openai_size("1:1"), "1024x1024");
+        assert_eq!(openai_size("16:9"), "1536x1024");
+        assert_eq!(openai_size("9:16"), "1024x1536");
+        assert_eq!(openai_size("auto"), "auto");
+        assert_eq!(openai_size("unexpected"), "auto");
+    }
+
+    #[tokio::test]
+    async fn openai_generation_matches_codex_images_contract() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/images/generations"))
+            .and(header("authorization", "Bearer codex-token"))
+            .and(header("originator", "codex_cli_rs"))
+            .and(header(CODEX_IMAGE_TURN_ID_HEADER, "turn-123"))
+            .and(body_json(serde_json::json!({
+                "model": OPENAI_IMAGE_MODEL,
+                "prompt": "a red fox",
+                "background": "auto",
+                "quality": "auto",
+                "size": "1536x1024",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{"b64_json": base64::engine::general_purpose::STANDARD.encode(b"png")}]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = ImageGenClient::new(&openai_config(server.uri()), None).unwrap();
+        assert_eq!(client.provider(), ImageGenerationProvider::OpenAi);
+        assert_eq!(client.model, OPENAI_IMAGE_MODEL);
+        assert_eq!(
+            client
+                .generate("a red fox", "16:9", "turn-123")
+                .await
+                .unwrap(),
+            b"png"
+        );
+        assert!(!client.is_tier_restricted());
+    }
+
+    #[tokio::test]
+    async fn openai_edit_uses_image_url_array() {
+        let server = MockServer::start().await;
+        let references = vec!["data:image/png;base64,AAAA".to_owned()];
+        Mock::given(method("POST"))
+            .and(path("/images/edits"))
+            .and(header(CODEX_IMAGE_TURN_ID_HEADER, "turn-edit"))
+            .and(body_json(serde_json::json!({
+                "model": OPENAI_IMAGE_MODEL,
+                "prompt": "make it blue",
+                "background": "auto",
+                "quality": "auto",
+                "size": "1024x1536",
+                "images": [{"image_url": "data:image/png;base64,AAAA"}],
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{"b64_json": base64::engine::general_purpose::STANDARD.encode(b"edited")}]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = ImageGenClient::new(&openai_config(server.uri()), None).unwrap();
+        assert_eq!(
+            client
+                .edit("make it blue", &references, "9:16", "turn-edit")
+                .await
+                .unwrap(),
+            b"edited"
+        );
+    }
+
+    #[tokio::test]
+    async fn image_tool_reuses_logical_turn_id_across_calls() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/images/generations"))
+            .and(header(CODEX_IMAGE_TURN_ID_HEADER, "logical-turn"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{"b64_json": base64::engine::general_purpose::STANDARD.encode(b"png")}]
+            })))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let client = ImageGenClient::new(&openai_config(server.uri()), None).unwrap();
+        let session = tempfile::tempdir().unwrap();
+        let mut resources = crate::types::resources::Resources::new();
+        resources.insert(client);
+        resources.insert(SessionFolder(session.path().to_path_buf()));
+        resources.insert(ImageGenerationTurnId("logical-turn".to_owned()));
+        let resources = resources.into_shared();
+
+        for call_id in ["call-one", "call-two"] {
+            let output = xai_tool_runtime::Tool::run(
+                &ImageGenTool,
+                test_ctx_with_call_id(resources.clone(), call_id),
+                ImageGenInput {
+                    prompt: "test".to_owned(),
+                    aspect_ratio: "auto".to_owned(),
+                },
+            )
+            .await
+            .unwrap();
+            assert!(matches!(output, ToolOutput::ImageGen(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn openai_live_auth_fails_closed_without_current_bearer() {
+        #[derive(Debug)]
+        struct MissingBearer;
+        impl crate::types::ApiKeyProvider for MissingBearer {
+            fn current_api_key(&self) -> Option<String> {
+                None
+            }
+        }
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/images/generations"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": [{"b64_json": base64::engine::general_purpose::STANDARD.encode(b"png")}]
+            })))
+            .expect(0)
+            .mount(&server)
+            .await;
+        let mut config = openai_config(server.uri());
+        let ImageGenConfig::Enabled {
+            api_key_provider, ..
+        } = &mut config
+        else {
+            unreachable!()
+        };
+        *api_key_provider = Some(Arc::new(MissingBearer));
+
+        let error = ImageGenClient::new(&config, None)
+            .unwrap()
+            .generate("test", "auto", "turn")
+            .await
+            .expect_err("a missing live Codex bearer must fail before egress");
+        assert!(error.to_string().contains("login --codex"));
+        let requests = server.received_requests().await.unwrap();
+        assert!(requests.is_empty(), "no prompt may leave without live auth");
+    }
+
+    #[test]
     fn per_tool_gates_are_independent() {
         let cfg = ImageGenConfig::Enabled {
+            provider: ImageGenerationProvider::Grok,
             api_key: "k".into(),
             base_url: "https://api.x.ai/v1".into(),
             extra_headers: indexmap::IndexMap::new(),
+            api_key_provider: None,
             image_gen_enabled: false,
             image_edit_enabled: true,
             model_override: Some("grok-imagine-image".into()),
@@ -525,9 +874,11 @@ mod tests {
     #[test]
     fn stamp_session_id_header_sets_and_preserves() {
         let mk = |headers: indexmap::IndexMap<String, String>| ImageGenConfig::Enabled {
+            provider: ImageGenerationProvider::Grok,
             api_key: "k".into(),
             base_url: "https://api.x.ai/v1".into(),
             extra_headers: headers,
+            api_key_provider: None,
             image_gen_enabled: true,
             image_edit_enabled: true,
             model_override: None,
@@ -563,9 +914,11 @@ mod tests {
     #[test]
     fn client_selects_model_from_override() {
         let mk = |model_override: Option<&str>| ImageGenConfig::Enabled {
+            provider: ImageGenerationProvider::Grok,
             api_key: "k".into(),
             base_url: "https://api.x.ai/v1".into(),
             extra_headers: indexmap::IndexMap::new(),
+            api_key_provider: None,
             image_gen_enabled: true,
             image_edit_enabled: true,
             model_override: model_override.map(String::from),
@@ -594,9 +947,11 @@ mod tests {
     #[test]
     fn client_selects_edit_model_from_override() {
         let mk = |edit_model_override: Option<&str>| ImageGenConfig::Enabled {
+            provider: ImageGenerationProvider::Grok,
             api_key: "k".into(),
             base_url: "https://api.x.ai/v1".into(),
             extra_headers: indexmap::IndexMap::new(),
+            api_key_provider: None,
             image_gen_enabled: true,
             image_edit_enabled: true,
             model_override: None,
@@ -647,9 +1002,11 @@ mod tests {
         // relay it. Only the client is inserted — the short-circuit returns
         // before any other resource (e.g. SessionFolder) is required.
         let cfg = ImageGenConfig::Enabled {
+            provider: ImageGenerationProvider::Grok,
             api_key: "k".into(),
             base_url: "https://api.x.ai/v1".into(),
             extra_headers: indexmap::IndexMap::new(),
+            api_key_provider: None,
             image_gen_enabled: true,
             image_edit_enabled: true,
             model_override: None,

--- a/crates/codegen/xai-grok-tools/src/types/resources.rs
+++ b/crates/codegen/xai-grok-tools/src/types/resources.rs
@@ -795,6 +795,10 @@ impl AvailableSkills {
 /// Session folder for logs and output files.
 #[derive(Debug, Clone)]
 pub struct SessionFolder(pub PathBuf);
+/// Correlation ID shared by every image generation/edit call in one logical
+/// agent turn. Replaced at the start of each turn and reused across retries.
+#[derive(Debug, Clone)]
+pub struct ImageGenerationTurnId(pub String);
 /// Per-turn registry mapping each attached image's `[Image #N]` display
 /// number to a reference `image_edit` can resolve.
 ///

--- a/crates/codegen/xai-grok-workspace/src/session/tool_config.rs
+++ b/crates/codegen/xai-grok-workspace/src/session/tool_config.rs
@@ -419,9 +419,11 @@ impl SessionContextFactory for WorkspaceSessionContextFactory {
                         let headers = build_proxy_headers(url);
                         (
                             ImageGenConfig::Enabled {
+                                provider: xai_grok_config_types::ImageGenerationProvider::Grok,
                                 api_key: token.clone(),
                                 base_url: url.clone(),
                                 extra_headers: headers.clone(),
+                                api_key_provider: None,
                                 image_gen_enabled: true,
                                 image_edit_enabled: true,
                                 model_override: None,

--- a/docs/agents/providers.md
+++ b/docs/agents/providers.md
@@ -135,7 +135,12 @@ Also isolated:
 8. **OpenCode Go transport is model-owned.** `@ai-sdk/anthropic` entries use Messages + `x-api-key`; OpenAI-compatible entries use Chat Completions + Bearer. Never choose the protocol from the provider alone.
 9. **Wafer AI is API-key-only and provider-local.** `WAFER_API_KEY` is sent only to `https://pass.wafer.ai/v1`; its dynamic `/models` catalog, client function tools, and standard metadata do not inherit xAI behavior. Wafer has no native hosted web search.
 10. **xAI-only services** (relay, some uploads, etc.) close via monotonic export boundary after non-xAI denied profiles. Compatibility field name remains `ever_used_codex` even when the triggering provider is not Codex; subagents mark the parent tree.
-11. **xAI media / Imagine** must not receive another provider's credential; hide media tools outside eligible xAI sessions.
+11. **Image generation is explicitly routed.** The default `grok` route uses
+    xAI Imagine credentials and remains hidden outside eligible xAI sessions.
+    Selecting `openai` in Settings is an explicit cross-provider opt-in: it
+    uses only the isolated Codex OAuth store, calls the Codex Images endpoint,
+    blocks known ChatGPT Free accounts, and never reuses an xAI credential.
+    Video generation remains xAI-only.
 12. **Hosted search** is dialect-scoped: xAI web/X search vs OpenAI `web_search`. Optional client search fallbacks are declared only when the provider profile permits them. Never infer this from model names or URLs.
 13. **Opaque history** (e.g. Codex compaction carriers, xAI-only items) is projected only by the matching dialect.
 14. **Standalone search is route-scoped.** Official Codex OAuth Responses
@@ -198,7 +203,7 @@ Follow [`../provider-architecture.md`](../provider-architecture.md):
    - API-key: `ApiKeyOnly` policy, scoped storage, empty live resolver.
    - OAuth: **separate file** (like `codex-auth.json`), own `BearerResolver`, fail-closed identity, never xAI `AuthManager`.
 5. If `xai_services: Denied`, participate in monotonic export boundary (`ever_used_codex` field name frozen for compatibility).
-6. Filter hosted + local tools by provider; never reuse another provider’s credentials for media/search.
+6. Filter hosted + local tools by provider; never reuse another provider’s credentials for media/search. The user-selected OpenAI Images route is the explicit exception for cross-provider image use, but its Codex credential and endpoint remain isolated.
 7. Add table-driven registry coverage + request/stream/tool/credential-isolation/retry/export-boundary tests.
 8. Custom endpoints may reuse an existing profile + explicit API key; unknown remote catalog providers fail closed.
 

--- a/docs/agents/tools.md
+++ b/docs/agents/tools.md
@@ -292,7 +292,7 @@ Paths under `xai-grok-tools/src/implementations/` unless noted.
 | Ask user | `ask_user_question` | `grok_build/ask_user_question/` | Reverse RPC to UI; timeout config |
 | Goals | `update_goal` | `grok_build/update_goal/` | Goal tracker in shell session |
 | Todo | `todo` / OpenCode `todowrite` | `grok_build/todo/`, `opencode/todowrite/` | Persisted plan state |
-| Image / video | `image_gen`, `image_edit`, image/ref → video | `grok_build/image_*`, `video_gen/` | Imagine APIs; config + API key provider |
+| Image / video | `image_gen`, `image_edit`, image/ref → video | `grok_build/image_*`, `video_gen/` | Settings selects Grok Imagine or OpenAI Images for image tools; video remains xAI-only |
 | LSP | `lsp` | `grok_build/lsp/` + `implementations/lsp/` | Shared handle from shell |
 | Memory | `memory_search`, `memory_get` | `memory/` | Needs `memory_backend` in session context |
 | Skills | skill invoke + discovery | `skills/`, `opencode/skill/` | Discovery reminder; types in `skills/types.rs` |

--- a/docs/agents/tui-and-config.md
+++ b/docs/agents/tui-and-config.md
@@ -120,6 +120,15 @@ swarm_mode = false
 - **Live UI:** an active session shows a bold `swarm` footer badge. Swarm children render in one foldable purple card with a pulsing purple accent, fixed input-order tree slots, running/queued/completed/failed/cancelled counts, elapsed time, tool/turn counts, and context usage. Ordinary subagent cards use warm orange identity chrome, while their terminal bullets still turn green or red. Child tracking remains available through the tasks pane and framed transcript view.
 - **Dispatch contract:** pager one-shot submission uses one ordered effect (`swarm_mode_changed` before `session/prompt`). If either send fails before the prompt is accepted, the optimistic turn is rolled back and the draft is restored.
 
+### Image generation provider
+
+`[ui].image_generation_provider = "grok" | "openai"` is exposed as
+**Settings → Models → Image generation** and applies after restart. `grok`
+uses the existing xAI Imagine route and credentials. `openai` mirrors Codex's
+client-side image extension with `gpt-image-2`, the Codex Images endpoints, and
+the isolated `codex-auth.json` bearer/account headers. It is not the hosted
+Responses `image_generation` declaration. Video generation remains xAI-only.
+
 ### Antigravity subagents
 
 ```toml

--- a/docs/codex-provider-port.md
+++ b/docs/codex-provider-port.md
@@ -11,6 +11,10 @@ revision as the Code Mode port:
 The live model-catalog, per-turn routing, response-stream, and compaction
 compatibility passes were refreshed against Codex commit
 `0f44bca9154e056a32fde7a89026b4620599e6f2`.
+The client-side image-generation extension was refreshed against Codex `main`
+at `6d4d9442c7142c08ac5c5098dfd6e82d8cd9f65a`; this includes the
+`x-codex-image-turn-id` correlation added by upstream commit
+`6219b7c40fc9`.
 
 ## Live model catalog
 
@@ -215,10 +219,22 @@ compiled local xAI search model. The local tool remains hidden across in-place
 model switches unless the user configured a non-default search model, which is
 treated as an explicit cross-provider opt-in.
 
-xAI Imagine media tools are provider scoped. Codex bearer tokens are never
-reused as static credentials for xAI image or video endpoints, and xAI media
-tools are hidden while Codex is active, including after an in-place model
-switch.
+Image generation follows codex-rs's client-extension shape rather than
+advertising the hosted Responses `image_generation` tool. Settings can select
+**Grok Imagine** (the default) or **OpenAI Images**:
+
+- Grok Imagine remains xAI-scoped. Codex bearer tokens are never reused for
+  xAI image or video endpoints, and these tools stay hidden on non-xAI routes.
+- OpenAI Images calls `POST /images/generations` and `/images/edits` below the
+  Codex inference base, uses `gpt-image-2`, includes the Codex originator,
+  account/FedRAMP headers, and `x-codex-image-turn-id`, and resolves the live
+  bearer only from the identity-anchored `codex-auth.json` credential.
+- Known ChatGPT Free accounts do not receive the OpenAI image tools, matching
+  codex-rs's plan gate. Unknown plan labels fail open to the server's
+  authoritative entitlement check.
+- The OpenAI selection is an explicit cross-provider opt-in, so an xAI or
+  third-party chat model may use OpenAI Images without credential crossover.
+  Video generation remains xAI-only.
 
 ## Maintenance
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- port the OpenAI Codex client-side image generation/editing contract behind Open Grok's existing `image_gen` and `image_edit` tools
- add a Settings selector for Grok Imagine or OpenAI Images with provider-isolated credentials and retries
- preserve xAI-only video generation and document the provider/auth boundaries

## Upstream comparison
- reviewed `openai/codex` main and the image extension introduced in `ecb41fcb64f22445b051d3943fc970d2ce51d0cd`
- mirrors `gpt-image-2`, Codex Images endpoints, account/FedRAMP/originator headers, Free-plan gating, and `x-codex-image-turn-id`
- intentionally does not advertise the hosted Responses `image_generation` tool

## Testing
- not completed at the author's request
- the first focused build exposed a dependency cycle in the pushed revision; a local follow-up fix was prepared, but the Cloud workspace detached before it could be committed and pushed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fccd2-8d6f-7e8d-8226-2ffafbe499bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fccd2-8d6f-7e8d-8226-2ffafbe499bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

