### PR TITLE
Add prompt-cache hit rate and prefix-break diagnostics

### DIFF
--- a/crates/codegen/xai-grok-pager/docs/user-guide/04-slash-commands.md
+++ b/crates/codegen/xai-grok-pager/docs/user-guide/04-slash-commands.md
@@ -43,6 +43,16 @@ Show how the context window is being used: a category breakdown (system prompt, 
 
 Show session details — auth method, model, turn count, and context usage. Aliases: `/status`, `/info`.
 
+### `/cache`
+
+Show this session's prompt-cache hit rate and where the KV-cache prefix last broke (model, tools, system prompt, or an earlier message). The report uses section labels and hashes only — prompt text is never shown. `/usage` also prints the session hit rate next to input tokens.
+
+Search logs for `shell.turn.prompt_cache`, `shell.turn.prompt_cache_break`, and `shell.turn.prompt_cache_miss` when debugging a miss.
+
+```
+/cache
+```
+
 ### `/fork`
 
 Branch the current session into a new agent, keeping history up to this point.
@@ -448,7 +458,8 @@ the independent OpenAI Codex account and keep the xAI session active.
 
 View xAI billing and OpenAI Codex quota usage together in one labeled summary.
 The two providers load independently, so one provider's error does not hide or
-alter the other. `/usage manage` opens xAI billing management. Alias: `/cost`.
+alter the other. The session token block includes prompt-cache hit rate; `/cache`
+has the prefix-break log. `/usage manage` opens xAI billing management. Alias: `/cost`.
 
 ```
 /usage

--- a/crates/codegen/xai-grok-pager/src/app/actions.rs
+++ b/crates/codegen/xai-grok-pager/src/app/actions.rs
@@ -838,6 +838,8 @@ pub enum Action {
     ShowContextInfo,
     /// `/usage` — session token/cost, plus consumer credits when visible.
     ShowUsage,
+    /// `/cache` — session prompt-cache hit rate and prefix-break log.
+    ShowCache,
     /// `/usage manage` — open consumer billing (no-op if surface hidden).
     ManageBilling,
     /// Commit a read-only list of the queued prompts as a system block
@@ -2483,6 +2485,11 @@ pub enum Effect {
         /// Usage-modal fetch generation; echoed back on the task result.
         nonce: u64,
     },
+    /// Fetch prompt-cache hit rate and prefix breaks via `x.ai/session/cache`.
+    FetchSessionCache {
+        agent_id: AgentId,
+        session_id: acp::SessionId,
+    },
     /// Re-fetch remote settings to check subscription gate.
     RefreshGate,
     /// Spawn a debounce sleep task for shell suggestions. `agent_id` rides
@@ -3295,6 +3302,18 @@ pub enum TaskResult {
         session_id: acp::SessionId,
         error: String,
         nonce: u64,
+    },
+    /// `/cache` report fetched. Drop if `session_id` no longer matches.
+    SessionCacheComplete {
+        agent_id: AgentId,
+        session_id: acp::SessionId,
+        text: String,
+    },
+    /// `/cache` fetch failed. Drop if `session_id` no longer matches.
+    SessionCacheFailed {
+        agent_id: AgentId,
+        session_id: acp::SessionId,
+        error: String,
     },
     /// Feedback submitted successfully (fire-and-forget).
     FeedbackComplete {

--- a/crates/codegen/xai-grok-pager/src/app/dispatch/router.rs
+++ b/crates/codegen/xai-grok-pager/src/app/dispatch/router.rs
@@ -111,8 +111,9 @@ use super::settings::ui::{
 use super::status::{
     dispatch_copy_session_id, dispatch_manage_billing, dispatch_open_gboom, dispatch_open_tutorial,
     dispatch_privacy_banner_opt_in, dispatch_privacy_banner_opt_out, dispatch_share_session,
-    dispatch_show_context_info, dispatch_show_queue, dispatch_show_release_notes,
-    dispatch_show_session_info, dispatch_show_tasks, dispatch_show_usage, set_coding_data_sharing,
+    dispatch_show_cache, dispatch_show_context_info, dispatch_show_queue,
+    dispatch_show_release_notes, dispatch_show_session_info, dispatch_show_tasks,
+    dispatch_show_usage, set_coding_data_sharing,
 };
 use super::task_result::{dispatch_task_result, unregister_all_active_sessions};
 use super::transcript::{
@@ -1038,6 +1039,7 @@ pub(crate) fn dispatch(action: Action, app: &mut AppView) -> Vec<Effect> {
         Action::ResetSessionTitleToAuto => dispatch_reset_session_title(app),
         Action::ShowContextInfo => dispatch_show_context_info(app),
         Action::ShowUsage => dispatch_show_usage(app),
+        Action::ShowCache => dispatch_show_cache(app),
         Action::ManageBilling => dispatch_manage_billing(app),
         Action::ShowQueue => dispatch_show_queue(app),
         Action::ShowTasks => dispatch_show_tasks(app),

--- a/crates/codegen/xai-grok-pager/src/app/dispatch/status.rs
+++ b/crates/codegen/xai-grok-pager/src/app/dispatch/status.rs
@@ -373,6 +373,41 @@ pub(super) fn dispatch_show_usage(app: &mut AppView) -> Vec<Effect> {
     }
 }
 
+/// `/cache` — always a scrollback system block (no modal). Prefix hashes
+/// and hit rates come from the session tracker via `x.ai/session/cache`.
+pub(super) fn dispatch_show_cache(app: &mut AppView) -> Vec<Effect> {
+    let ActiveView::Agent(id) = app.active_view else {
+        return vec![];
+    };
+    let Some(agent) = app.agents.get_mut(&id) else {
+        return vec![];
+    };
+    let Some(session_id) = agent.session.session_id.clone() else {
+        return vec![];
+    };
+    vec![Effect::FetchSessionCache {
+        agent_id: id,
+        session_id,
+    }]
+}
+
+/// Commit a `/cache` report (or error) if still on `session_id`.
+pub(super) fn handle_session_cache_result(
+    app: &mut AppView,
+    agent_id: AgentId,
+    session_id: &acp::SessionId,
+    text: String,
+) -> Vec<Effect> {
+    let Some(agent) = app.agents.get_mut(&agent_id) else {
+        return vec![];
+    };
+    if agent.session.session_id.as_ref() != Some(session_id) {
+        return vec![];
+    }
+    push_and_page_flip(&mut agent.scrollback, RenderBlock::system(text));
+    vec![]
+}
+
 /// Route a session-usage result (success or failure text) into the open
 /// usage modal, or into scrollback in minimal mode. Stale results are dropped.
 pub(super) fn handle_session_usage_result(

--- a/crates/codegen/xai-grok-pager/src/app/dispatch/task_result.rs
+++ b/crates/codegen/xai-grok-pager/src/app/dispatch/task_result.rs
@@ -46,8 +46,8 @@ use super::session::modal::remove_agent_and_cleanup;
 use super::settings::ui::{apply_setting_rollback, refresh_open_settings_modals};
 use super::status::{
     handle_coding_data_sharing_failed, handle_coding_data_sharing_updated,
-    handle_context_info_complete, handle_session_usage_result, scrub_error_for_toast,
-    usage_modal_state_mut,
+    handle_context_info_complete, handle_session_cache_result, handle_session_usage_result,
+    scrub_error_for_toast, usage_modal_state_mut,
 };
 use super::transcript::{
     handle_hooks_list_loaded, handle_marketplace_list_loaded, handle_marketplace_updates_available,
@@ -4018,6 +4018,21 @@ pub(super) fn dispatch_task_result(result: TaskResult, app: &mut AppView) -> Vec
             &session_id,
             format!("Couldn't load session usage: {error}"),
             nonce,
+        ),
+        TaskResult::SessionCacheComplete {
+            agent_id,
+            session_id,
+            text,
+        } => handle_session_cache_result(app, agent_id, &session_id, text),
+        TaskResult::SessionCacheFailed {
+            agent_id,
+            session_id,
+            error,
+        } => handle_session_cache_result(
+            app,
+            agent_id,
+            &session_id,
+            format!("Couldn't load prompt cache: {error}"),
         ),
         TaskResult::FeedbackComplete { .. } => vec![],
         TaskResult::FeedbackFailed { agent_id, error } => {

--- a/crates/codegen/xai-grok-pager/src/app/dispatch/tests/status.rs
+++ b/crates/codegen/xai-grok-pager/src/app/dispatch/tests/status.rs
@@ -952,6 +952,60 @@ fn show_usage_on_welcome_screen_is_noop() {
 }
 
 #[test]
+fn show_cache_on_welcome_screen_is_noop() {
+    let mut app = test_app();
+    let effects = dispatch(Action::ShowCache, &mut app);
+    assert!(
+        effects.is_empty(),
+        "ShowCache with no active agent should be a no-op"
+    );
+}
+
+#[test]
+fn show_cache_fetches_session_cache() {
+    let mut app = test_app_with_agent();
+    let effects = dispatch(Action::ShowCache, &mut app);
+    assert!(
+        matches!(
+            effects.as_slice(),
+            [Effect::FetchSessionCache { agent_id, .. }] if *agent_id == AgentId(0)
+        ),
+        "got: {effects:?}"
+    );
+}
+
+#[test]
+fn session_cache_complete_commits_scrollback() {
+    let mut app = test_app_with_agent();
+    let before = agent_scrollback_len(&app);
+    let effects = dispatch(
+        Action::TaskComplete(TaskResult::SessionCacheComplete {
+            agent_id: AgentId(0),
+            session_id: "test-session".to_string().into(),
+            text: "Prompt cache: no model calls yet in this session.".to_string(),
+        }),
+        &mut app,
+    );
+    assert!(effects.is_empty());
+    assert_eq!(agent_scrollback_len(&app), before + 1);
+}
+
+#[test]
+fn session_cache_result_drops_stale_session() {
+    let mut app = test_app_with_agent();
+    let before = agent_scrollback_len(&app);
+    dispatch(
+        Action::TaskComplete(TaskResult::SessionCacheComplete {
+            agent_id: AgentId(0),
+            session_id: "other-session".to_string().into(),
+            text: "stale".to_string(),
+        }),
+        &mut app,
+    );
+    assert_eq!(agent_scrollback_len(&app), before);
+}
+
+#[test]
 fn show_usage_with_redirect_url_fetches_session_only() {
     // Redirect link is deferred until SessionUsageComplete (see billing tests).
     let mut app = test_app_with_agent();

--- a/crates/codegen/xai-grok-pager/src/app/effects/mod.rs
+++ b/crates/codegen/xai-grok-pager/src/app/effects/mod.rs
@@ -5674,6 +5674,28 @@ pub(crate) fn execute(
                     }
                 });
         }
+        Effect::FetchSessionCache { agent_id, session_id } => {
+            let tx = acp_tx.clone();
+            tasks
+                .spawn(async move {
+                    match fetch_session_cache(&session_id, &tx).await {
+                        Ok(text) => {
+                            TaskResult::SessionCacheComplete {
+                                agent_id,
+                                session_id,
+                                text,
+                            }
+                        }
+                        Err(error) => {
+                            TaskResult::SessionCacheFailed {
+                                agent_id,
+                                session_id,
+                                error,
+                            }
+                        }
+                    }
+                });
+        }
         Effect::SendFeedback { agent_id, session_id, feedback_text } => {
             use xai_grok_shell::session::ClientType;
             use xai_grok_shell::session::acp_types::ClientFeedbackInput;
@@ -6700,6 +6722,38 @@ async fn fetch_session_usage(
             "invalid session usage response".to_string()
         })?;
     Ok(parsed.usage)
+}
+async fn fetch_session_cache(
+    session_id: &acp::SessionId,
+    tx: &AcpAgentTx,
+) -> Result<String, String> {
+    let request = acp::ExtRequest::new(
+        "x.ai/session/cache",
+        serde_json::value::to_raw_value(
+                &serde_json::json!({
+            "sessionId": session_id.0.to_string()
+        }),
+            )
+            .expect("serialize session/cache params")
+            .into(),
+    );
+    let resp = acp_send(request, tx)
+        .await
+        .map_err(|e| {
+            if i32::from(e.code) == i32::from(acp::Error::method_not_found().code) {
+                "not supported by this agent version".to_string()
+            } else {
+                sanitize_user_error(&e.to_string())
+            }
+        })?;
+    let parsed: xai_grok_shell::extensions::cache::SessionCacheResponse = serde_json::from_str(
+            resp.0.get(),
+        )
+        .map_err(|e| {
+            tracing::debug!("session cache deser failed: {e}");
+            "invalid session cache response".to_string()
+        })?;
+    Ok(parsed.text)
 }
 /// Shared `x.ai/session/rename` RPC for rename and `/rename --auto`.
 async fn session_rename_rpc(

--- a/crates/codegen/xai-grok-pager/src/app/snapshots/xai_grok_pager__app__status_blocks__tests__session_usage_block_absent_cost.snap
+++ b/crates/codegen/xai-grok-pager/src/app/snapshots/xai_grok_pager__app__status_blocks__tests__session_usage_block_absent_cost.snap
@@ -4,6 +4,7 @@ expression: text
 ---
 Session usage (since start or last resume):
   Input tokens:   100 (0 cached)
+  Cache hit rate: 0.0% (0 / 100)
   Output tokens:  10 (0 reasoning)
   Total tokens:   110
   Model calls:    1 · API time: 1.0s

--- a/crates/codegen/xai-grok-pager/src/app/snapshots/xai_grok_pager__app__status_blocks__tests__session_usage_block_full.snap
+++ b/crates/codegen/xai-grok-pager/src/app/snapshots/xai_grok_pager__app__status_blocks__tests__session_usage_block_full.snap
@@ -4,6 +4,7 @@ expression: text
 ---
 Session usage (since start or last resume):
   Input tokens:   1,234,567 (1,000,000 cached)
+  Cache hit rate: 81.0% (1,000,000 / 1,234,567)
   Output tokens:  45,678 (12,000 reasoning)
   Total tokens:   1,280,245
   Model calls:    42 · API time: 3m12s

--- a/crates/codegen/xai-grok-pager/src/app/status_blocks.rs
+++ b/crates/codegen/xai-grok-pager/src/app/status_blocks.rs
@@ -199,6 +199,15 @@ pub(crate) fn session_usage_block_text(
         group_thousands(t.cached_read_tokens),
     ));
     rows.push(format!(
+        "  Cache hit rate: {} ({} / {})",
+        xai_grok_shell::sampling::format_cache_hit_rate(xai_grok_shell::sampling::cache_hit_rate(
+            t.cached_read_tokens,
+            t.input_tokens,
+        )),
+        group_thousands(t.cached_read_tokens),
+        group_thousands(t.input_tokens),
+    ));
+    rows.push(format!(
         "  Output tokens:  {} ({} reasoning)",
         group_thousands(t.output_tokens),
         group_thousands(t.reasoning_tokens),
@@ -327,6 +336,10 @@ mod tests {
             ..Default::default()
         };
         let text = session_usage_block_text(&usage);
+        assert!(
+            text.contains("Cache hit rate: 81.0% (1,000,000 / 1,234,567)"),
+            "{text}"
+        );
         // Snapshot pins content and column alignment together; single-model
         // sessions must skip the redundant by-model breakdown.
         insta::assert_snapshot!("session_usage_block_full", text);

--- a/crates/codegen/xai-grok-pager/src/slash/commands/cache.rs
+++ b/crates/codegen/xai-grok-pager/src/slash/commands/cache.rs
@@ -1,0 +1,61 @@
+//! `/cache` — session prompt-cache hit rate and prefix-break log.
+
+use crate::app::actions::Action;
+use crate::slash::command::{CommandExecCtx, CommandResult, SlashCommand};
+
+/// Show prompt-cache hit rate and where the prefix last broke.
+pub struct CacheCommand;
+
+impl SlashCommand for CacheCommand {
+    fn name(&self) -> &str {
+        "cache"
+    }
+
+    fn description(&self) -> &str {
+        "View prompt cache hit rate and prefix breaks"
+    }
+
+    fn session_scoped(&self) -> bool {
+        true
+    }
+
+    fn usage(&self) -> &str {
+        "/cache"
+    }
+
+    fn run(&self, ctx: &mut CommandExecCtx, _args: &str) -> CommandResult {
+        if ctx.session_id.is_none() {
+            return CommandResult::Error("No active session".to_string());
+        }
+        CommandResult::Action(Action::ShowCache)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::acp::model_state::ModelState;
+    use crate::slash::commands::tests::make_ctx;
+
+    #[test]
+    fn cache_requires_a_session() {
+        let models = ModelState::default();
+        let mut ctx = make_ctx(&models);
+        match CacheCommand.run(&mut ctx, "") {
+            CommandResult::Error(msg) => assert!(msg.contains("No active session")),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cache_with_session_emits_show_cache() {
+        let models = ModelState::default();
+        let session_id = agent_client_protocol::SessionId::new("sess-1");
+        let mut ctx = make_ctx(&models);
+        ctx.session_id = Some(&session_id);
+        assert!(matches!(
+            CacheCommand.run(&mut ctx, ""),
+            CommandResult::Action(Action::ShowCache)
+        ));
+    }
+}

--- a/crates/codegen/xai-grok-pager/src/slash/commands/mod.rs
+++ b/crates/codegen/xai-grok-pager/src/slash/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod always_approve;
 pub mod announcements;
 pub mod auto;
 pub mod btw;
+pub mod cache;
 pub mod cd;
 pub mod compact;
 pub mod compact_mode;
@@ -114,6 +115,7 @@ pub fn builtin_commands() -> Vec<Arc<dyn SlashCommand>> {
         Arc::new(plugin::SkillsCommand),
         Arc::new(share::ShareCommand),
         Arc::new(session_info::SessionInfoCommand),
+        Arc::new(cache::CacheCommand),
         Arc::new(rename::RenameCommand),
         Arc::new(dashboard::DashboardCommand),
         Arc::new(cd::CdCommand),
@@ -256,6 +258,7 @@ mod tests {
             "announcements",
             "auto",
             "btw",
+            "cache",
             "cd",
             "changelog",
             "chat",

--- a/crates/codegen/xai-grok-pager/src/slash/mod.rs
+++ b/crates/codegen/xai-grok-pager/src/slash/mod.rs
@@ -2163,6 +2163,7 @@ mod tests {
             "/rename",
             "/btw",
             "/session-info",
+            "/cache",
             "/find",
             "/doctor",
         ] {

--- a/crates/codegen/xai-grok-sampling-types/src/lib.rs
+++ b/crates/codegen/xai-grok-sampling-types/src/lib.rs
@@ -10,12 +10,19 @@ pub mod conversation;
 pub mod doom_loop;
 pub mod error;
 pub mod messages;
+pub mod prompt_cache;
 pub mod provider_error;
 pub mod serde_helpers;
 pub mod tool_overrides;
 pub mod types;
 
 pub use self::conversation::*;
+pub use self::prompt_cache::{
+    CacheBreak, CacheCallOutcome, CachePrefixDiff, PROVIDER_MISS_MIN_PROMPT_TOKENS,
+    PromptCacheFingerprint, PromptCacheReport, PromptCacheSection, PromptCacheSectionKind,
+    PromptCacheTracker, cache_hit_rate, diff_fingerprints, fingerprint_request,
+    format_cache_hit_rate,
+};
 pub use self::doom_loop::{
     DOOM_LOOP_CHECK_EVENT_TYPE, DOOM_LOOP_CHECK_HEADER, DoomLoopPeek, DoomLoopRecoveryPolicy,
     DoomLoopSignal, DoomLoopSignalKind, is_check_event, peek_doom_loop,

--- a/crates/codegen/xai-grok-sampling-types/src/prompt_cache.rs
+++ b/crates/codegen/xai-grok-sampling-types/src/prompt_cache.rs
@@ -1,0 +1,939 @@
+//! Prompt-cache hit rate and prefix-break diagnostics.
+//!
+//! Provider KV caches are prefix-addressed. A rewrite of an early request
+//! section (model, tools, system prompt, an earlier message) drops the hit
+//! rate even when later tokens are new. This module fingerprints those
+//! sections, diffs them across calls, and reports where the prefix first
+//! changed — without logging prompt text.
+
+use std::collections::VecDeque;
+use std::hash::Hasher;
+
+use serde::{Deserialize, Serialize};
+
+use crate::conversation::{
+    ContentPart, ConversationItem, ConversationRequest, CustomToolOutputContent, HostedTool,
+    SyntheticReason, TokenUsage, ToolSpec,
+};
+
+/// Minimum prompt size before a 0% hit on a stable prefix is treated as a
+/// provider miss (routing / TTL / key not applied) rather than "too small
+/// to cache".
+pub const PROVIDER_MISS_MIN_PROMPT_TOKENS: u64 = 1_024;
+
+const MAX_RECENT_BREAKS: usize = 16;
+
+/// `cached / prompt` as a percentage in `[0, 100]`. `None` when `prompt` is 0.
+pub fn cache_hit_rate(cached_tokens: u64, prompt_tokens: u64) -> Option<f64> {
+    (prompt_tokens > 0).then(|| (cached_tokens as f64 / prompt_tokens as f64) * 100.0)
+}
+
+/// Human-readable hit rate (`"72.4%"` or `"n/a"`).
+pub fn format_cache_hit_rate(rate: Option<f64>) -> String {
+    match rate {
+        Some(rate) => format!("{rate:.1}%"),
+        None => "n/a".to_string(),
+    }
+}
+
+/// Kind of a prefix-stable request section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptCacheSectionKind {
+    Model,
+    ReasoningEffort,
+    Temperature,
+    PromptCacheKey,
+    ToolChoice,
+    JsonSchema,
+    Tools,
+    HostedTools,
+    Item,
+}
+
+/// One ordered prefix section and its content hash.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PromptCacheSection {
+    pub kind: PromptCacheSectionKind,
+    /// Stable label such as `tools` or `item[3]:user`. Never prompt text.
+    pub label: String,
+    pub hash: u64,
+}
+
+/// Ordered fingerprint of the request prefix that the KV cache keys on.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct PromptCacheFingerprint {
+    pub sections: Vec<PromptCacheSection>,
+}
+
+impl PromptCacheFingerprint {
+    pub fn is_empty(&self) -> bool {
+        self.sections.is_empty()
+    }
+}
+
+/// How the current request prefix compares to the previous one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum CachePrefixDiff {
+    /// First request in this process — no prior prefix to compare.
+    ColdStart,
+    /// Every previous section is unchanged and no new sections were added.
+    Identical,
+    /// Previous sections are a prefix of the current request (new suffix only).
+    PrefixExtended { shared_sections: usize },
+    /// Current request is a strict prefix of the previous one (rewind / trim).
+    /// Remaining prefix is intact, so this is not counted as a cache break.
+    Shortened { at: usize, section: String },
+    /// An earlier section changed. This is the first place the KV cache breaks.
+    Broke {
+        at: usize,
+        section: String,
+        previous_label: String,
+        previous_hash: String,
+        current_label: String,
+        current_hash: String,
+    },
+}
+
+impl CachePrefixDiff {
+    pub fn is_break(&self) -> bool {
+        matches!(self, Self::Broke { .. })
+    }
+
+    pub fn break_section(&self) -> Option<&str> {
+        match self {
+            Self::Broke { section, .. } => Some(section.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn summary(&self) -> String {
+        match self {
+            Self::ColdStart => "cold start".to_string(),
+            Self::Identical => "intact".to_string(),
+            Self::PrefixExtended { shared_sections } => {
+                format!("extended ({shared_sections} shared sections)")
+            }
+            Self::Shortened { section, .. } => format!("shortened after {section}"),
+            Self::Broke {
+                section,
+                previous_label,
+                previous_hash,
+                current_label,
+                current_hash,
+                ..
+            } => {
+                if previous_label == current_label {
+                    format!("broke at {section} ({previous_hash} → {current_hash})")
+                } else {
+                    format!(
+                        "broke at {section} (was {previous_label} {previous_hash}, now {current_label} {current_hash})"
+                    )
+                }
+            }
+        }
+    }
+}
+
+/// One recorded prefix rewrite, for `/cache` and logs.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheBreak {
+    pub call_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub loop_index: Option<u32>,
+    pub section: String,
+    pub previous_label: String,
+    pub previous_hash: String,
+    pub current_label: String,
+    pub current_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hit_rate_percent: Option<f64>,
+}
+
+/// Outcome of folding one model call's usage into the tracker.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CacheCallOutcome {
+    pub diff: CachePrefixDiff,
+    pub hit_rate: Option<f64>,
+    pub cached_tokens: u64,
+    pub prompt_tokens: u64,
+    /// Stable prefix, prompt large enough to cache, but the provider reported
+    /// zero cached tokens.
+    pub provider_miss: bool,
+}
+
+/// Session-scoped prompt-cache accumulator.
+#[derive(Debug, Clone, Default)]
+pub struct PromptCacheTracker {
+    last: Option<PromptCacheFingerprint>,
+    last_diff: Option<CachePrefixDiff>,
+    pending_break: Option<CacheBreak>,
+    calls: u64,
+    prompt_tokens: u64,
+    cached_tokens: u64,
+    cache_creation_tokens: u64,
+    prefix_breaks: u64,
+    provider_misses: u64,
+    last_call_hit_rate: Option<f64>,
+    last_call_cached: u64,
+    last_call_prompt: u64,
+    last_call_cache_key_forwarded: Option<bool>,
+    breaks: VecDeque<CacheBreak>,
+}
+
+impl PromptCacheTracker {
+    /// Fingerprint `request` and compare it to the previous main-turn prefix.
+    /// Auxiliary calls must not use this — they would poison the next turn.
+    pub fn record_request(&mut self, request: &ConversationRequest) -> CachePrefixDiff {
+        let current = fingerprint_request(request);
+        let diff = match self.last.as_ref() {
+            None => CachePrefixDiff::ColdStart,
+            Some(previous) => diff_fingerprints(previous, &current),
+        };
+        if let CachePrefixDiff::Broke {
+            section,
+            previous_label,
+            previous_hash,
+            current_label,
+            current_hash,
+            ..
+        } = &diff
+        {
+            self.pending_break = Some(CacheBreak {
+                call_kind: String::new(),
+                loop_index: None,
+                section: section.clone(),
+                previous_label: previous_label.clone(),
+                previous_hash: previous_hash.clone(),
+                current_label: current_label.clone(),
+                current_hash: current_hash.clone(),
+                hit_rate_percent: None,
+            });
+        } else {
+            self.pending_break = None;
+        }
+        self.last = Some(current);
+        self.last_diff = Some(diff.clone());
+        diff
+    }
+
+    /// Fold provider-reported cache usage for the request last passed to
+    /// [`Self::record_request`].
+    pub fn record_usage(
+        &mut self,
+        usage: &TokenUsage,
+        cache_key_forwarded: bool,
+        call_kind: &str,
+        loop_index: Option<u32>,
+    ) -> CacheCallOutcome {
+        let prompt_tokens = u64::from(usage.prompt_tokens);
+        let cached_tokens = u64::from(usage.cached_prompt_tokens);
+        let hit_rate = cache_hit_rate(cached_tokens, prompt_tokens);
+        let diff = self
+            .last_diff
+            .clone()
+            .unwrap_or(CachePrefixDiff::ColdStart);
+        let prefix_stable = matches!(
+            diff,
+            CachePrefixDiff::Identical | CachePrefixDiff::PrefixExtended { .. }
+        );
+        let provider_miss = prefix_stable
+            && cache_key_forwarded
+            && prompt_tokens >= PROVIDER_MISS_MIN_PROMPT_TOKENS
+            && cached_tokens == 0;
+
+        self.calls = self.calls.saturating_add(1);
+        self.prompt_tokens = self.prompt_tokens.saturating_add(prompt_tokens);
+        self.cached_tokens = self.cached_tokens.saturating_add(cached_tokens);
+        self.cache_creation_tokens = self
+            .cache_creation_tokens
+            .saturating_add(u64::from(usage.cache_creation_prompt_tokens));
+        self.last_call_hit_rate = hit_rate;
+        self.last_call_cached = cached_tokens;
+        self.last_call_prompt = prompt_tokens;
+        self.last_call_cache_key_forwarded = Some(cache_key_forwarded);
+
+        if let Some(mut brk) = self.pending_break.take() {
+            brk.call_kind = call_kind.to_string();
+            brk.loop_index = loop_index;
+            brk.hit_rate_percent = hit_rate;
+            self.prefix_breaks = self.prefix_breaks.saturating_add(1);
+            push_break(&mut self.breaks, brk);
+        }
+        if provider_miss {
+            self.provider_misses = self.provider_misses.saturating_add(1);
+        }
+
+        CacheCallOutcome {
+            diff,
+            hit_rate,
+            cached_tokens,
+            prompt_tokens,
+            provider_miss,
+        }
+    }
+
+    pub fn snapshot(&self) -> PromptCacheReport {
+        PromptCacheReport {
+            session_hit_rate_percent: cache_hit_rate(self.cached_tokens, self.prompt_tokens),
+            last_call_hit_rate_percent: self.last_call_hit_rate,
+            calls: self.calls,
+            prompt_tokens: self.prompt_tokens,
+            cached_tokens: self.cached_tokens,
+            cache_creation_tokens: self.cache_creation_tokens,
+            prefix_breaks: self.prefix_breaks,
+            provider_misses: self.provider_misses,
+            last_call_cached_tokens: self.last_call_cached,
+            last_call_prompt_tokens: self.last_call_prompt,
+            last_call_cache_key_forwarded: self.last_call_cache_key_forwarded,
+            last_prefix: self.last_diff.as_ref().map(CachePrefixDiff::summary),
+            recent_breaks: self.breaks.iter().cloned().collect(),
+        }
+    }
+}
+
+fn push_break(breaks: &mut VecDeque<CacheBreak>, brk: CacheBreak) {
+    if breaks.len() == MAX_RECENT_BREAKS {
+        breaks.pop_front();
+    }
+    breaks.push_back(brk);
+}
+
+/// Wire snapshot for `x.ai/session/cache` and `/cache`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptCacheReport {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_hit_rate_percent: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_call_hit_rate_percent: Option<f64>,
+    pub calls: u64,
+    pub prompt_tokens: u64,
+    pub cached_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub prefix_breaks: u64,
+    pub provider_misses: u64,
+    pub last_call_cached_tokens: u64,
+    pub last_call_prompt_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_call_cache_key_forwarded: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_prefix: Option<String>,
+    pub recent_breaks: Vec<CacheBreak>,
+}
+
+impl PromptCacheReport {
+    /// Human-readable `/cache` body. Contains labels and hashes only.
+    pub fn format_report(&self) -> String {
+        if self.calls == 0 {
+            return "Prompt cache: no model calls yet in this session.\n\
+                    Prefix tracking starts on the first inference."
+                .to_string();
+        }
+
+        let mut lines = vec![
+            "Prompt cache (this session):".to_string(),
+            format!(
+                "  Session hit rate:  {}  ({} / {})",
+                format_cache_hit_rate(self.session_hit_rate_percent),
+                group_thousands(self.cached_tokens),
+                group_thousands(self.prompt_tokens),
+            ),
+            format!(
+                "  Last call:         {}  ({} / {})",
+                format_cache_hit_rate(self.last_call_hit_rate_percent),
+                group_thousands(self.last_call_cached_tokens),
+                group_thousands(self.last_call_prompt_tokens),
+            ),
+            format!("  Model calls:       {}", group_thousands(self.calls)),
+            format!("  Prefix breaks:     {}", group_thousands(self.prefix_breaks)),
+            format!(
+                "  Provider misses:   {}  (stable prefix, 0% hit, prompt ≥ {})",
+                group_thousands(self.provider_misses),
+                group_thousands(PROVIDER_MISS_MIN_PROMPT_TOKENS),
+            ),
+        ];
+        if self.cache_creation_tokens > 0 {
+            lines.push(format!(
+                "  Cache writes:      {}",
+                group_thousands(self.cache_creation_tokens)
+            ));
+        }
+        if let Some(forwarded) = self.last_call_cache_key_forwarded {
+            lines.push(format!(
+                "  Cache key on wire: {}",
+                if forwarded { "yes" } else { "no (backend does not send it)" }
+            ));
+        }
+        if let Some(prefix) = &self.last_prefix {
+            lines.push(format!("  Last prefix:       {prefix}"));
+        }
+        if !self.recent_breaks.is_empty() {
+            lines.push("  Recent breaks:".to_string());
+            for (i, brk) in self.recent_breaks.iter().enumerate() {
+                let hit = format_cache_hit_rate(brk.hit_rate_percent);
+                let loop_bit = brk
+                    .loop_index
+                    .map(|n| format!(" loop {n}"))
+                    .unwrap_or_default();
+                lines.push(format!(
+                    "    {}. {}{}  {}  ({} → {})  hit {hit}",
+                    i + 1,
+                    brk.section,
+                    loop_bit,
+                    brk.call_kind,
+                    brk.previous_hash,
+                    brk.current_hash,
+                ));
+            }
+        }
+        lines.push(
+            "  Logs: search for shell.turn.prompt_cache_break / shell.turn.prompt_cache".to_string(),
+        );
+        lines.join("\n")
+    }
+}
+
+/// Fingerprint the prefix-stable parts of a conversation request.
+pub fn fingerprint_request(request: &ConversationRequest) -> PromptCacheFingerprint {
+    let mut sections = Vec::with_capacity(8 + request.items.len());
+    push_section(
+        &mut sections,
+        PromptCacheSectionKind::Model,
+        "model",
+        hash_opt_str(request.model.as_deref()),
+    );
+    push_section(
+        &mut sections,
+        PromptCacheSectionKind::ReasoningEffort,
+        "reasoning_effort",
+        hash_opt_str(request.reasoning_effort.map(|e| e.as_str())),
+    );
+    push_section(
+        &mut sections,
+        PromptCacheSectionKind::Temperature,
+        "temperature",
+        hash_opt_f32(request.temperature),
+    );
+    push_section(
+        &mut sections,
+        PromptCacheSectionKind::PromptCacheKey,
+        "prompt_cache_key",
+        hash_opt_str(request.prompt_cache_key.as_deref()),
+    );
+    push_section(
+        &mut sections,
+        PromptCacheSectionKind::ToolChoice,
+        "tool_choice",
+        hash_json(&request.tool_choice),
+    );
+    push_section(
+        &mut sections,
+        PromptCacheSectionKind::JsonSchema,
+        "json_schema",
+        hash_json(&request.json_schema),
+    );
+    push_section(
+        &mut sections,
+        PromptCacheSectionKind::Tools,
+        "tools",
+        hash_tools(&request.tools),
+    );
+    push_section(
+        &mut sections,
+        PromptCacheSectionKind::HostedTools,
+        "hosted_tools",
+        hash_hosted_tools(&request.hosted_tools),
+    );
+    for (index, item) in request.items.iter().enumerate() {
+        let (kind_label, hash) = hash_item(item);
+        push_section(
+            &mut sections,
+            PromptCacheSectionKind::Item,
+            format!("item[{index}]:{kind_label}"),
+            hash,
+        );
+    }
+    PromptCacheFingerprint { sections }
+}
+
+/// First differing section, or an expected grow/shrink of an intact prefix.
+pub fn diff_fingerprints(
+    previous: &PromptCacheFingerprint,
+    current: &PromptCacheFingerprint,
+) -> CachePrefixDiff {
+    let shared = previous.sections.len().min(current.sections.len());
+    for i in 0..shared {
+        let prev = &previous.sections[i];
+        let curr = &current.sections[i];
+        if prev.hash != curr.hash || prev.label != curr.label {
+            return CachePrefixDiff::Broke {
+                at: i,
+                section: curr.label.clone(),
+                previous_label: prev.label.clone(),
+                previous_hash: format_hash(prev.hash),
+                current_label: curr.label.clone(),
+                current_hash: format_hash(curr.hash),
+            };
+        }
+    }
+    match previous.sections.len().cmp(&current.sections.len()) {
+        std::cmp::Ordering::Equal => CachePrefixDiff::Identical,
+        std::cmp::Ordering::Less => CachePrefixDiff::PrefixExtended {
+            shared_sections: shared,
+        },
+        std::cmp::Ordering::Greater => CachePrefixDiff::Shortened {
+            at: shared,
+            section: previous
+                .sections
+                .get(shared)
+                .map(|s| s.label.clone())
+                .unwrap_or_else(|| "end".to_string()),
+        },
+    }
+}
+
+fn push_section(
+    sections: &mut Vec<PromptCacheSection>,
+    kind: PromptCacheSectionKind,
+    label: impl Into<String>,
+    hash: u64,
+) {
+    sections.push(PromptCacheSection {
+        kind,
+        label: label.into(),
+        hash,
+    });
+}
+
+fn format_hash(hash: u64) -> String {
+    format!("{hash:016x}")
+}
+
+fn group_thousands(n: u64) -> String {
+    let raw = n.to_string();
+    let mut out = String::with_capacity(raw.len() + raw.len() / 3);
+    for (i, ch) in raw.chars().enumerate() {
+        if i > 0 && (raw.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn hash_finish(hasher: impl Hasher) -> u64 {
+    hasher.finish()
+}
+
+fn hash_bytes(bytes: &[u8]) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    hasher.write(bytes);
+    hash_finish(hasher)
+}
+
+fn hash_opt_str(value: Option<&str>) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    match value {
+        Some(s) => {
+            hasher.write_u8(1);
+            hasher.write(s.as_bytes());
+        }
+        None => hasher.write_u8(0),
+    }
+    hash_finish(hasher)
+}
+
+fn hash_opt_f32(value: Option<f32>) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    match value {
+        Some(v) => {
+            hasher.write_u8(1);
+            hasher.write_u32(v.to_bits());
+        }
+        None => hasher.write_u8(0),
+    }
+    hash_finish(hasher)
+}
+
+fn hash_json<T: Serialize>(value: &T) -> u64 {
+    match serde_json::to_vec(value) {
+        Ok(bytes) => hash_bytes(&bytes),
+        Err(_) => 0,
+    }
+}
+
+fn hash_tools(tools: &[ToolSpec]) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    hasher.write_usize(tools.len());
+    for tool in tools {
+        hasher.write(tool.name.as_bytes());
+        hasher.write_u8(0);
+        if let Some(description) = tool.description.as_deref() {
+            hasher.write(description.as_bytes());
+        }
+        hasher.write_u8(0);
+        if let Ok(params) = serde_json::to_vec(&tool.parameters) {
+            hasher.write(&params);
+        }
+        hasher.write_u8(0xff);
+    }
+    hash_finish(hasher)
+}
+
+fn hash_hosted_tools(tools: &[HostedTool]) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    hasher.write_usize(tools.len());
+    for tool in tools {
+        hasher.write(tool.wire_name().as_bytes());
+        hasher.write_u8(0);
+        match tool {
+            HostedTool::WebSearch { options } => {
+                if let Ok(bytes) = serde_json::to_vec(options) {
+                    hasher.write(&bytes);
+                }
+            }
+            HostedTool::XSearch { options } => {
+                if let Ok(bytes) = serde_json::to_vec(options) {
+                    hasher.write(&bytes);
+                }
+            }
+            HostedTool::ClientCustom(spec) => {
+                if let Ok(bytes) = serde_json::to_vec(spec) {
+                    hasher.write(&bytes);
+                }
+            }
+        }
+        hasher.write_u8(0xff);
+    }
+    hash_finish(hasher)
+}
+
+fn hash_item(item: &ConversationItem) -> (&'static str, u64) {
+    match item {
+        ConversationItem::System(sys) => ("system", hash_bytes(sys.content.as_bytes())),
+        ConversationItem::User(user) => {
+            let label = match user.synthetic_reason.as_ref() {
+                Some(SyntheticReason::ProjectInstructions) => "user:project_instructions",
+                Some(SyntheticReason::SystemReminder) => "user:system_reminder",
+                Some(SyntheticReason::CompactionMeta) => "user:compaction_meta",
+                Some(SyntheticReason::AutoContinue) => "user:auto_continue",
+                Some(SyntheticReason::AutoRecovery) => "user:auto_recovery",
+                Some(SyntheticReason::Interjection) => "user:interjection",
+                Some(SyntheticReason::TaskCompleted) => "user:task_completed",
+                Some(SyntheticReason::SubagentCompleted) => "user:subagent_completed",
+                Some(SyntheticReason::NotificationDrain) => "user:notification_drain",
+                Some(SyntheticReason::GoalSummary) => "user:goal_summary",
+                Some(SyntheticReason::GoalClassifierNudge) => "user:goal_classifier_nudge",
+                Some(SyntheticReason::SchedulerFired) => "user:scheduler_fired",
+                Some(SyntheticReason::AgentMessage) => "user:agent_message",
+                Some(SyntheticReason::StopHookFeedback) => "user:stop_hook_feedback",
+                Some(SyntheticReason::WorkingDirectorySwitch) => "user:cwd_switch",
+                Some(SyntheticReason::Unknown) => "user:synthetic",
+                None => "user",
+            };
+            (label, hash_content_parts(&user.content))
+        }
+        ConversationItem::Assistant(asst) => {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            hasher.write(asst.content.as_bytes());
+            hasher.write_u8(0);
+            hasher.write_usize(asst.tool_calls.len());
+            for call in &asst.tool_calls {
+                hasher.write(call.id.as_bytes());
+                hasher.write(call.name.as_bytes());
+                hasher.write(call.arguments.as_bytes());
+            }
+            ("assistant", hash_finish(hasher))
+        }
+        ConversationItem::ToolResult(result) => {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            hasher.write(result.tool_call_id.as_bytes());
+            hasher.write(result.content.as_bytes());
+            hasher.write_u8(0);
+            hash_content_parts_into(&mut hasher, &result.images);
+            for part in &result.ordered_content {
+                hash_custom_output_into(&mut hasher, part);
+            }
+            ("tool_result", hash_finish(hasher))
+        }
+        ConversationItem::CustomToolOutput(output) => {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            hasher.write(output.call_id.as_bytes());
+            if let Some(name) = output.name.as_deref() {
+                hasher.write(name.as_bytes());
+            }
+            for part in &output.content {
+                hash_custom_output_into(&mut hasher, part);
+            }
+            ("custom_tool_output", hash_finish(hasher))
+        }
+        ConversationItem::BackendToolCall(call) => {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            hasher.write(call.id().as_bytes());
+            hasher.write(call.text_summary().as_bytes());
+            ("backend_tool_call", hash_finish(hasher))
+        }
+        ConversationItem::Reasoning(reasoning) => ("reasoning", hash_json(reasoning)),
+    }
+}
+
+fn hash_content_parts(parts: &[ContentPart]) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    hash_content_parts_into(&mut hasher, parts);
+    hash_finish(hasher)
+}
+
+fn hash_content_parts_into(hasher: &mut std::collections::hash_map::DefaultHasher, parts: &[ContentPart]) {
+    hasher.write_usize(parts.len());
+    for part in parts {
+        match part {
+            ContentPart::Text { text } => {
+                hasher.write_u8(1);
+                hasher.write(text.as_bytes());
+            }
+            ContentPart::Image { url } => {
+                hasher.write_u8(2);
+                hasher.write(url.as_bytes());
+            }
+        }
+    }
+}
+
+fn hash_custom_output_into(
+    hasher: &mut std::collections::hash_map::DefaultHasher,
+    part: &CustomToolOutputContent,
+) {
+    match part {
+        CustomToolOutputContent::Text { text } => {
+            hasher.write_u8(1);
+            hasher.write(text.as_bytes());
+        }
+        CustomToolOutputContent::Image { url, detail } => {
+            hasher.write_u8(2);
+            hasher.write(url.as_bytes());
+            hasher.write_u8(*detail as u8);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conversation::{AssistantItem, ConversationItem, SystemItem, UserItem};
+    use std::sync::Arc;
+
+    fn usage(prompt: u32, cached: u32) -> TokenUsage {
+        TokenUsage {
+            prompt_tokens: prompt,
+            completion_tokens: 10,
+            total_tokens: prompt + 10,
+            reasoning_tokens: 0,
+            cached_prompt_tokens: cached,
+            cache_creation_prompt_tokens: 0,
+        }
+    }
+
+    fn request_with_items(items: Vec<ConversationItem>) -> ConversationRequest {
+        ConversationRequest {
+            items,
+            model: Some("grok-4".to_string()),
+            prompt_cache_key: Some("sess-1".to_string()),
+            ..ConversationRequest::default()
+        }
+    }
+
+    fn system(text: &str) -> ConversationItem {
+        ConversationItem::System(SystemItem {
+            content: Arc::<str>::from(text),
+        })
+    }
+
+    fn user(text: &str) -> ConversationItem {
+        ConversationItem::user(text)
+    }
+
+    fn assistant(text: &str) -> ConversationItem {
+        ConversationItem::Assistant(AssistantItem {
+            content: Arc::<str>::from(text),
+            tool_calls: vec![],
+            model_id: None,
+            model_fingerprint: None,
+            reasoning_effort: None,
+        })
+    }
+
+    #[test]
+    fn hit_rate_is_none_when_prompt_is_zero() {
+        assert_eq!(cache_hit_rate(0, 0), None);
+        assert_eq!(format_cache_hit_rate(None), "n/a");
+    }
+
+    #[test]
+    fn hit_rate_covers_zero_full_and_partial() {
+        assert_eq!(cache_hit_rate(0, 100), Some(0.0));
+        assert_eq!(cache_hit_rate(100, 100), Some(100.0));
+        let partial = cache_hit_rate(1_000_000, 1_234_567).expect("rate");
+        assert!((partial - 81.000_072).abs() < 0.001);
+        assert_eq!(format_cache_hit_rate(Some(72.41)), "72.4%");
+    }
+
+    #[test]
+    fn fingerprint_is_stable_for_identical_requests() {
+        let req = request_with_items(vec![system("sys"), user("hi")]);
+        assert_eq!(fingerprint_request(&req), fingerprint_request(&req));
+    }
+
+    #[test]
+    fn system_rewrite_breaks_at_first_item() {
+        let prev = fingerprint_request(&request_with_items(vec![system("sys-a"), user("hi")]));
+        let curr = fingerprint_request(&request_with_items(vec![system("sys-b"), user("hi")]));
+        match diff_fingerprints(&prev, &curr) {
+            CachePrefixDiff::Broke { section, .. } => {
+                assert_eq!(section, "item[0]:system");
+            }
+            other => panic!("expected break, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_rewrite_breaks_before_items() {
+        let mut prev_req = request_with_items(vec![system("sys")]);
+        prev_req.tools = vec![ToolSpec {
+            name: "bash".to_string(),
+            description: Some("run".to_string()),
+            parameters: serde_json::json!({"type": "object"}),
+        }];
+        let mut curr_req = prev_req.clone();
+        curr_req.tools[0].description = Some("run a command".to_string());
+        match diff_fingerprints(&fingerprint_request(&prev_req), &fingerprint_request(&curr_req))
+        {
+            CachePrefixDiff::Broke { section, .. } => assert_eq!(section, "tools"),
+            other => panic!("expected tools break, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn appended_user_turn_is_prefix_extended() {
+        let prev = fingerprint_request(&request_with_items(vec![system("sys"), user("hi")]));
+        let curr = fingerprint_request(&request_with_items(vec![
+            system("sys"),
+            user("hi"),
+            assistant("hello"),
+            user("again"),
+        ]));
+        assert_eq!(
+            diff_fingerprints(&prev, &curr),
+            CachePrefixDiff::PrefixExtended { shared_sections: 10 }
+        );
+    }
+
+    #[test]
+    fn rewind_is_shortened_not_a_break() {
+        let prev = fingerprint_request(&request_with_items(vec![
+            system("sys"),
+            user("hi"),
+            assistant("hello"),
+        ]));
+        let curr = fingerprint_request(&request_with_items(vec![system("sys"), user("hi")]));
+        match diff_fingerprints(&prev, &curr) {
+            CachePrefixDiff::Shortened { .. } => {}
+            other => panic!("expected shortened, got {other:?}"),
+        }
+        assert!(!diff_fingerprints(&prev, &curr).is_break());
+    }
+
+    #[test]
+    fn tracker_session_hit_rate_and_break_history() {
+        let mut tracker = PromptCacheTracker::default();
+        let mut req = request_with_items(vec![system("sys"), user("hi")]);
+        let cold = tracker.record_request(&req);
+        assert_eq!(cold, CachePrefixDiff::ColdStart);
+        let outcome = tracker.record_usage(&usage(2_000, 0), true, "turn", Some(0));
+        assert!(!outcome.provider_miss, "cold start is not a provider miss");
+
+        req.items.push(assistant("ok"));
+        req.items.push(user("next"));
+        let extended = tracker.record_request(&req);
+        assert!(matches!(extended, CachePrefixDiff::PrefixExtended { .. }));
+        let hit = tracker.record_usage(&usage(3_000, 2_000), true, "turn", Some(1));
+        assert!(!hit.provider_miss);
+        assert_eq!(hit.hit_rate, Some(2_000.0 / 3_000.0 * 100.0));
+
+        req.items[0] = system("rewritten");
+        let broke = tracker.record_request(&req);
+        assert!(broke.is_break());
+        tracker.record_usage(&usage(3_000, 100), true, "turn", Some(2));
+
+        let report = tracker.snapshot();
+        assert_eq!(report.calls, 3);
+        assert_eq!(report.prefix_breaks, 1);
+        assert_eq!(report.prompt_tokens, 8_000);
+        assert_eq!(report.cached_tokens, 2_100);
+        assert_eq!(report.recent_breaks.len(), 1);
+        assert_eq!(report.recent_breaks[0].section, "item[0]:system");
+        assert!(report.format_report().contains("Session hit rate"));
+        assert!(report.format_report().contains("item[0]:system"));
+    }
+
+    #[test]
+    fn stable_prefix_zero_hit_on_large_prompt_is_provider_miss() {
+        let mut tracker = PromptCacheTracker::default();
+        let req = request_with_items(vec![system("sys"), user("hi")]);
+        tracker.record_request(&req);
+        tracker.record_usage(&usage(2_000, 1_500), true, "turn", Some(0));
+
+        let mut next = req;
+        next.items.push(assistant("ok"));
+        tracker.record_request(&next);
+        let miss = tracker.record_usage(&usage(2_500, 0), true, "turn", Some(1));
+        assert!(miss.provider_miss);
+        assert_eq!(tracker.snapshot().provider_misses, 1);
+    }
+
+    #[test]
+    fn unforwarded_cache_key_is_not_a_provider_miss() {
+        let mut tracker = PromptCacheTracker::default();
+        let req = request_with_items(vec![system("sys")]);
+        tracker.record_request(&req);
+        tracker.record_usage(&usage(2_000, 0), false, "turn", Some(0));
+        tracker.record_request(&req);
+        let outcome = tracker.record_usage(&usage(2_000, 0), false, "turn", Some(1));
+        assert!(!outcome.provider_miss);
+        assert_eq!(tracker.snapshot().provider_misses, 0);
+    }
+
+    #[test]
+    fn empty_report_explains_no_calls() {
+        let text = PromptCacheTracker::default().snapshot().format_report();
+        assert!(text.contains("no model calls yet"));
+    }
+
+    #[test]
+    fn user_synthetic_reason_is_in_the_section_label() {
+        let mut item = UserItem {
+            content: vec![ContentPart::Text {
+                text: Arc::<str>::from("AGENTS.md"),
+            }],
+            synthetic_reason: Some(SyntheticReason::ProjectInstructions),
+            cwd_generation: None,
+            prior_turn_interrupt: None,
+            prompt_index: None,
+        };
+        let fp = fingerprint_request(&request_with_items(vec![ConversationItem::User(item.clone())]));
+        assert!(
+            fp.sections
+                .iter()
+                .any(|s| s.label == "item[0]:user:project_instructions"),
+            "{:?}",
+            fp.sections
+        );
+        item.content = vec![ContentPart::Text {
+            text: Arc::<str>::from("AGENTS.md changed"),
+        }];
+        let next = fingerprint_request(&request_with_items(vec![ConversationItem::User(item)]));
+        assert!(diff_fingerprints(&fp, &next).is_break());
+    }
+}

--- a/crates/codegen/xai-grok-shell/src/agent/mvp_agent/acp_agent.rs
+++ b/crates/codegen/xai-grok-shell/src/agent/mvp_agent/acp_agent.rs
@@ -2822,6 +2822,7 @@ impl acp::Agent for MvpAgent {
             }
             "x.ai/session/repair" => crate::extensions::repair::handle(self, &args).await,
             "x.ai/session/usage" => crate::extensions::usage::handle(self, &args).await,
+            "x.ai/session/cache" => crate::extensions::cache::handle(self, &args).await,
             "x.ai/memory/flush" | "x.ai/memory/rewrite" => {
                 crate::extensions::memory::handle(self, &args).await
             }

--- a/crates/codegen/xai-grok-shell/src/agent/mvp_agent/tests.rs
+++ b/crates/codegen/xai-grok-shell/src/agent/mvp_agent/tests.rs
@@ -1387,6 +1387,9 @@ fn make_test_handle(
         resolved_tool_overrides: std::sync::Arc::new(arc_swap::ArcSwapOption::empty()),
         hunk_tracker_handle,
         chat_state_handle: xai_chat_state::ChatStateHandle::noop(),
+        prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+            xai_grok_sampling_types::PromptCacheTracker::default(),
+        )),
         signals_handle: crate::session::signals::SessionSignalsHandle::new(),
         gateway_enabled: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
         mcp_servers: vec![],
@@ -2198,6 +2201,14 @@ fn session_usage_request(session_id: &str) -> acp::ExtRequest {
             .into(),
     )
 }
+fn session_cache_request(session_id: &str) -> acp::ExtRequest {
+    acp::ExtRequest::new(
+        "x.ai/session/cache",
+        serde_json::value::to_raw_value(&serde_json::json!({ "sessionId": session_id }))
+            .unwrap()
+            .into(),
+    )
+}
 #[tokio::test(flavor = "current_thread")]
 async fn session_usage_unknown_session_is_resource_not_found() {
     let agent = build_minimal_agent_for_tests();
@@ -2221,6 +2232,32 @@ async fn session_usage_dead_chat_state_actor_fails_closed() {
             .await
             .expect_err("dead chat-state actor");
     assert_eq!(err.code, acp::Error::internal_error().code);
+}
+#[tokio::test(flavor = "current_thread")]
+async fn session_cache_unknown_session_is_resource_not_found() {
+    let agent = build_minimal_agent_for_tests();
+    let err = crate::extensions::cache::handle(&agent, &session_cache_request("no-such-session"))
+        .await
+        .expect_err("unknown session");
+    assert_eq!(
+        err.code,
+        acp::Error::resource_not_found(None::<String>).code
+    );
+}
+#[tokio::test(flavor = "current_thread")]
+async fn session_cache_empty_tracker_returns_report() {
+    let agent = build_minimal_agent_for_tests();
+    let sid = acp::SessionId::new("cache-empty-sess");
+    let mut handle = make_test_handle("test-model", false, None);
+    handle.info.id = sid.clone();
+    agent.insert_resident(&sid, handle);
+    let resp = crate::extensions::cache::handle(&agent, &session_cache_request("cache-empty-sess"))
+        .await
+        .expect("live session");
+    let parsed: crate::extensions::cache::SessionCacheResponse =
+        serde_json::from_str(resp.0.get()).expect("cache response");
+    assert_eq!(parsed.report.calls, 0);
+    assert!(parsed.text.contains("no model calls yet"));
 }
 /// The session responses publish the value THIS session's spawn pinned, so a
 /// client describing `/loop` fires can never contradict what the fires do.

--- a/crates/codegen/xai-grok-shell/src/extensions/cache.rs
+++ b/crates/codegen/xai-grok-shell/src/extensions/cache.rs
@@ -1,0 +1,82 @@
+//! `x.ai/session/cache` — session prompt-cache hit rate and prefix breaks.
+
+use agent_client_protocol as acp;
+use serde::{Deserialize, Serialize};
+
+use super::{ExtResult, parse_params, to_raw_response};
+use crate::agent::MvpAgent;
+use xai_grok_sampling_types::PromptCacheReport;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SessionCacheRequest {
+    session_id: String,
+}
+
+/// Wire response for `x.ai/session/cache`.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionCacheResponse {
+    pub report: PromptCacheReport,
+    pub text: String,
+}
+
+#[tracing::instrument(skip_all, fields(method = %args.method))]
+pub async fn handle(agent: &MvpAgent, args: &acp::ExtRequest) -> ExtResult {
+    match args.method.as_ref() {
+        "x.ai/session/cache" => handle_session_cache(agent, args).await,
+        _ => Err(acp::Error::method_not_found()),
+    }
+}
+
+async fn handle_session_cache(agent: &MvpAgent, args: &acp::ExtRequest) -> ExtResult {
+    let req: SessionCacheRequest = parse_params(args)?;
+    let session_id = acp::SessionId::new(req.session_id.as_str());
+
+    let Some(handle) = agent.session_handle_waiting_for_load(&session_id).await else {
+        return Err(acp::Error::resource_not_found(Some(format!(
+            "session not found: {}",
+            req.session_id
+        ))));
+    };
+
+    let report = handle.prompt_cache.lock().snapshot();
+    to_raw_response(&SessionCacheResponse {
+        text: report.format_report(),
+        report,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use xai_grok_sampling_types::{ConversationItem, ConversationRequest, PromptCacheTracker};
+
+    #[test]
+    fn response_serializes_empty_report() {
+        let report = PromptCacheTracker::default().snapshot();
+        let v = serde_json::to_value(&SessionCacheResponse {
+            text: report.format_report(),
+            report,
+        })
+        .unwrap();
+        assert_eq!(v["report"]["calls"], 0);
+        assert!(v["text"].as_str().unwrap().contains("no model calls yet"));
+    }
+
+    #[test]
+    fn fingerprint_round_trips_through_the_wire_report() {
+        let mut tracker = PromptCacheTracker::default();
+        let request = ConversationRequest {
+            items: vec![
+                ConversationItem::system("sys"),
+                ConversationItem::user("hi"),
+            ],
+            model: Some("grok-4".into()),
+            ..ConversationRequest::default()
+        };
+        tracker.record_request(&request);
+        let report = tracker.snapshot();
+        assert_eq!(report.last_prefix.as_deref(), Some("cold start"));
+    }
+}

--- a/crates/codegen/xai-grok-shell/src/extensions/mod.rs
+++ b/crates/codegen/xai-grok-shell/src/extensions/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub(crate) mod auth_gate;
 pub mod billing;
+pub mod cache;
 pub mod bundle;
 pub(crate) mod chat_conversation_history;
 pub mod code_nav;

--- a/crates/codegen/xai-grok-shell/src/sampling/mod.rs
+++ b/crates/codegen/xai-grok-shell/src/sampling/mod.rs
@@ -7,6 +7,10 @@ pub mod types;
 // `SamplingClient` -- the two have identical method sets, so call-sites
 // compile unchanged.
 pub use self::conversation::*;
+pub use xai_grok_sampling_types::{
+    CacheBreak, CacheCallOutcome, CachePrefixDiff, PromptCacheReport, PromptCacheTracker,
+    cache_hit_rate, format_cache_hit_rate,
+};
 pub use self::error::{ResponseModelMetadata, Result, SamplingError};
 pub use self::types::*;
 pub use xai_grok_sampler::ApiBackend;

--- a/crates/codegen/xai-grok-shell/src/session/acp_session.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session.rs
@@ -191,6 +191,8 @@ mod rewind;
 mod run_loop;
 #[path = "acp_session_impl/session_setup.rs"]
 mod session_setup;
+#[path = "acp_session_impl/prompt_cache.rs"]
+mod prompt_cache;
 #[path = "acp_session_impl/side_call.rs"]
 mod side_call;
 #[path = "acp_session_impl/turn_end.rs"]
@@ -673,6 +675,10 @@ pub(crate) struct SessionActor {
     /// Also stores credentials (api_key, optional extra access key,
     /// client_version) opaquely.
     pub(crate) chat_state_handle: xai_chat_state::ChatStateHandle,
+    /// Main-turn prompt-cache prefix tracker. Auxiliary calls must not
+    /// record here — they would poison the next turn's prefix diff.
+    pub(crate) prompt_cache:
+        std::sync::Arc<parking_lot::Mutex<xai_grok_sampling_types::PromptCacheTracker>>,
     /// Current running prompt/turn id, shared with SessionHandle.
     pub(crate) current_prompt_id: std::sync::Arc<std::sync::Mutex<Option<String>>>,
     pub(crate) unattributed_background_usage: std::sync::atomic::AtomicBool,

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_impl/prompt_cache.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_impl/prompt_cache.rs
@@ -1,0 +1,81 @@
+//! Main-turn prompt-cache recording and log emission.
+
+use super::*;
+use xai_grok_sampling_types::{TokenUsage, format_cache_hit_rate};
+
+impl SessionActor {
+    /// Fingerprint the request that just completed, fold provider cache
+    /// numbers, and log a break or provider miss. Auxiliary calls must not
+    /// use this — they would poison the next main-turn prefix.
+    pub(crate) fn record_and_log_prompt_cache(
+        &self,
+        request: &ConversationRequest,
+        usage: &TokenUsage,
+        cache_key_forwarded: bool,
+        loop_index: u32,
+    ) {
+        let mut tracker = self.prompt_cache.lock();
+        let diff = tracker.record_request(request);
+        let outcome = tracker.record_usage(usage, cache_key_forwarded, "turn", Some(loop_index));
+        drop(tracker);
+
+        let session_id = self.session_info.id.0.as_ref();
+        let payload = serde_json::json!({
+            "loop_index": loop_index,
+            "prompt_tokens": outcome.prompt_tokens,
+            "cached_prompt_tokens": outcome.cached_tokens,
+            "hit_rate_percent": outcome.hit_rate,
+            "cache_key_forwarded": cache_key_forwarded,
+            "prefix": outcome.diff.summary(),
+            "provider_miss": outcome.provider_miss,
+            "break_section": outcome.diff.break_section(),
+        });
+        xai_grok_telemetry::unified_log::info(
+            "shell.turn.prompt_cache",
+            Some(session_id),
+            Some(payload.clone()),
+        );
+        tracing::info!(
+            target: SESSION_LOG,
+            loop_index,
+            cached_prompt_tokens = outcome.cached_tokens,
+            prompt_tokens = outcome.prompt_tokens,
+            hit_rate = format_cache_hit_rate(outcome.hit_rate),
+            cache_key_forwarded,
+            prefix = %outcome.diff.summary(),
+            "prompt cache"
+        );
+
+        if outcome.diff.is_break() {
+            xai_grok_telemetry::unified_log::info(
+                "shell.turn.prompt_cache_break",
+                Some(session_id),
+                Some(payload),
+            );
+            tracing::info!(
+                target: SESSION_LOG,
+                loop_index,
+                section = outcome.diff.break_section().unwrap_or("unknown"),
+                prefix = %diff.summary(),
+                hit_rate = format_cache_hit_rate(outcome.hit_rate),
+                cached_prompt_tokens = outcome.cached_tokens,
+                prompt_tokens = outcome.prompt_tokens,
+                "prompt cache prefix broke"
+            );
+        } else if outcome.provider_miss {
+            xai_grok_telemetry::unified_log::info(
+                "shell.turn.prompt_cache_miss",
+                Some(session_id),
+                Some(payload),
+            );
+            tracing::info!(
+                target: SESSION_LOG,
+                loop_index,
+                prefix = %outcome.diff.summary(),
+                prompt_tokens = outcome.prompt_tokens,
+                cache_key_forwarded,
+                "prompt cache provider miss"
+            );
+        }
+    }
+}

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_impl/side_call.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_impl/side_call.rs
@@ -14,10 +14,15 @@ pub(crate) fn log_prompt_cache_hit(
     let Some(usage) = response.usage.as_ref() else {
         return;
     };
+    let hit_rate = xai_grok_sampling_types::cache_hit_rate(
+        u64::from(usage.cached_prompt_tokens),
+        u64::from(usage.prompt_tokens),
+    );
     tracing::info!(
         call,
         cached_prompt_tokens = usage.cached_prompt_tokens,
         prompt_tokens = usage.prompt_tokens,
+        hit_rate = xai_grok_sampling_types::format_cache_hit_rate(hit_rate),
         cache_key_forwarded = backend.forwards_prompt_cache_key(),
         "auxiliary call prompt cache"
     );

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_impl/slash_exec.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_impl/slash_exec.rs
@@ -412,6 +412,11 @@ impl SessionActor {
                 self.send_host_turn_slash_command_output(&text).await;
                 ok_end_turn(0, None)
             }
+            BuiltinAction::Cache => {
+                let text = self.prompt_cache.lock().snapshot().format_report();
+                self.send_host_turn_slash_command_output(&text).await;
+                ok_end_turn(0, None)
+            }
             BuiltinAction::PluginsAdd { path } => {
                 if path.is_empty() {
                     self.send_host_turn_slash_command_output(

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_impl/spawn.rs
@@ -1710,6 +1710,9 @@ pub(crate) async fn spawn_session_actor(
     let resolved_tool_overrides: std::sync::Arc<
         arc_swap::ArcSwapOption<xai_grok_sampling_types::ToolOverrides>,
     > = std::sync::Arc::new(arc_swap::ArcSwapOption::empty());
+    let prompt_cache = std::sync::Arc::new(parking_lot::Mutex::new(
+        xai_grok_sampling_types::PromptCacheTracker::default(),
+    ));
     let session = Arc::new_cyclic(|weak: &std::sync::Weak<SessionActor>| SessionActor {
         session_info: session_info.clone(),
         auth_method_id,
@@ -1730,6 +1733,7 @@ pub(crate) async fn spawn_session_actor(
         mcp_strategy: std::cell::Cell::new(mcp_strategy),
         initial_client_mcp_servers: initial_client_mcp_servers.clone(),
         chat_state_handle,
+        prompt_cache: prompt_cache.clone(),
         unattributed_background_usage: std::sync::atomic::AtomicBool::new(false),
         current_prompt_id: current_prompt_id.clone(),
         pending_interactions: pending_interactions.clone(),
@@ -2279,6 +2283,7 @@ pub(crate) async fn spawn_session_actor(
             resolved_tool_overrides,
             hunk_tracker_handle,
             chat_state_handle: chat_state_handle_for_handle,
+            prompt_cache,
             signals_handle,
             gateway_enabled,
             mcp_servers,

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_impl/turn.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_impl/turn.rs
@@ -2845,6 +2845,14 @@ impl SessionActor {
                 })),
             );
             if let Some(usage) = response.usage.as_ref() {
+                self.record_and_log_prompt_cache(
+                    &request,
+                    usage,
+                    api_backend.forwards_prompt_cache_key(),
+                    loop_index,
+                );
+            }
+            if let Some(usage) = response.usage.as_ref() {
                 self.chat_state_handle
                     .record_token_usage(u64::from(usage.total_tokens));
                 self.send_available_commands_update().await;

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_tests/cancel_running_task_tests.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_tests/cancel_running_task_tests.rs
@@ -152,6 +152,9 @@ fn persist_ack_waits_for_disk_flush_before_success() {
                 delivery_tools: std::cell::RefCell::new(Vec::new()),
                 attach_non_interactive: std::cell::Cell::new(false),
                 chat_state_handle,
+                prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+                    xai_grok_sampling_types::PromptCacheTracker::default(),
+                )),
                 unattributed_background_usage: std::sync::atomic::AtomicBool::new(false),
                 current_prompt_id: std::sync::Arc::new(std::sync::Mutex::new(None)),
                 pending_interactions: std::sync::Arc::new(std::sync::Mutex::new(
@@ -646,6 +649,9 @@ fn first_turn_memory_injection_disabled_does_not_persist_to_chat_history() {
                 delivery_tools: std::cell::RefCell::new(Vec::new()),
                 attach_non_interactive: std::cell::Cell::new(false),
                 chat_state_handle,
+                prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+                    xai_grok_sampling_types::PromptCacheTracker::default(),
+                )),
                 unattributed_background_usage: std::sync::atomic::AtomicBool::new(false),
                 current_prompt_id: std::sync::Arc::new(std::sync::Mutex::new(None)),
                 pending_interactions: std::sync::Arc::new(std::sync::Mutex::new(
@@ -937,6 +943,9 @@ async fn cancel_running_task_teardown_clears_running_and_pending_work() {
                 delivery_tools: std::cell::RefCell::new(Vec::new()),
                 attach_non_interactive: std::cell::Cell::new(false),
                 chat_state_handle: xai_chat_state::ChatStateHandle::noop(),
+                prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+                    xai_grok_sampling_types::PromptCacheTracker::default(),
+                )),
                 unattributed_background_usage: std::sync::atomic::AtomicBool::new(false),
                 current_prompt_id: std::sync::Arc::new(
                     std::sync::Mutex::new(Some("running".to_string())),
@@ -2462,6 +2471,9 @@ async fn cancel_propagates_to_sampler_handle_so_no_further_emission() {
                 delivery_tools: std::cell::RefCell::new(Vec::new()),
                 attach_non_interactive: std::cell::Cell::new(false),
                 chat_state_handle: xai_chat_state::ChatStateHandle::noop(),
+                prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+                    xai_grok_sampling_types::PromptCacheTracker::default(),
+                )),
                 unattributed_background_usage: std::sync::atomic::AtomicBool::new(false),
                 current_prompt_id: std::sync::Arc::new(
                     std::sync::Mutex::new(Some("running".to_string())),

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_tests/idle_resume_tests.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_tests/idle_resume_tests.rs
@@ -172,6 +172,9 @@ async fn test_e2e_idle_resume_refreshes_model_metadata() {
                 delivery_tools: std::cell::RefCell::new(Vec::new()),
                 attach_non_interactive: std::cell::Cell::new(false),
                 chat_state_handle,
+                prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+                    xai_grok_sampling_types::PromptCacheTracker::default(),
+                )),
                 unattributed_background_usage: std::sync::atomic::AtomicBool::new(false),
                 current_prompt_id: std::sync::Arc::new(std::sync::Mutex::new(None)),
                 pending_interactions: std::sync::Arc::new(std::sync::Mutex::new(

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_tests/inline_auto_compact_flow_tests.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_tests/inline_auto_compact_flow_tests.rs
@@ -97,6 +97,9 @@ async fn create_test_actor(
         delivery_tools: std::cell::RefCell::new(Vec::new()),
         attach_non_interactive: std::cell::Cell::new(false),
         chat_state_handle,
+        prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+            xai_grok_sampling_types::PromptCacheTracker::default(),
+        )),
         unattributed_background_usage: std::sync::atomic::AtomicBool::new(false),
         current_prompt_id: std::sync::Arc::new(std::sync::Mutex::new(None)),
         pending_interactions: std::sync::Arc::new(std::sync::Mutex::new(
@@ -555,6 +558,9 @@ async fn create_test_actor_with_memory(
         delivery_tools: std::cell::RefCell::new(Vec::new()),
         attach_non_interactive: std::cell::Cell::new(false),
         chat_state_handle,
+        prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+            xai_grok_sampling_types::PromptCacheTracker::default(),
+        )),
         unattributed_background_usage: std::sync::atomic::AtomicBool::new(false),
         current_prompt_id: std::sync::Arc::new(std::sync::Mutex::new(None)),
         pending_interactions: std::sync::Arc::new(std::sync::Mutex::new(
@@ -1313,6 +1319,9 @@ async fn test_e2e_idle_resume_refreshes_model_metadata() {
                 delivery_tools: std::cell::RefCell::new(Vec::new()),
                 attach_non_interactive: std::cell::Cell::new(false),
                 chat_state_handle,
+                prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+                    xai_grok_sampling_types::PromptCacheTracker::default(),
+                )),
                 unattributed_background_usage: std::sync::atomic::AtomicBool::new(false),
                 current_prompt_id: std::sync::Arc::new(std::sync::Mutex::new(None)),
                 pending_interactions: std::sync::Arc::new(std::sync::Mutex::new(

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_tests/memory_config_tests.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_tests/memory_config_tests.rs
@@ -150,6 +150,9 @@ async fn create_test_actor_with_memory(
         delivery_tools: std::cell::RefCell::new(Vec::new()),
         attach_non_interactive: std::cell::Cell::new(false),
         chat_state_handle,
+        prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+            xai_grok_sampling_types::PromptCacheTracker::default(),
+        )),
         unattributed_background_usage: std::sync::atomic::AtomicBool::new(false),
         current_prompt_id: std::sync::Arc::new(std::sync::Mutex::new(None)),
         pending_interactions: std::sync::Arc::new(std::sync::Mutex::new(

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_tests/replay_buffer_send_update_tests.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_tests/replay_buffer_send_update_tests.rs
@@ -100,6 +100,9 @@ pub(super) async fn make_replay_send_update_fixture() -> ReplaySendUpdateFixture
         delivery_tools: std::cell::RefCell::new(Vec::new()),
         attach_non_interactive: std::cell::Cell::new(false),
         chat_state_handle: xai_chat_state::ChatStateHandle::noop(),
+        prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+            xai_grok_sampling_types::PromptCacheTracker::default(),
+        )),
         unattributed_background_usage: std::sync::atomic::AtomicBool::new(false),
         current_prompt_id: std::sync::Arc::new(std::sync::Mutex::new(None)),
         pending_interactions: std::sync::Arc::new(std::sync::Mutex::new(

--- a/crates/codegen/xai-grok-shell/src/session/acp_session_tests/support.rs
+++ b/crates/codegen/xai-grok-shell/src/session/acp_session_tests/support.rs
@@ -349,6 +349,9 @@ pub(crate) async fn create_test_actor_with_terminal(
         delivery_tools: std::cell::RefCell::new(Vec::new()),
         attach_non_interactive: std::cell::Cell::new(false),
         chat_state_handle,
+        prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+            xai_grok_sampling_types::PromptCacheTracker::default(),
+        )),
         unattributed_background_usage: std::sync::atomic::AtomicBool::new(false),
         current_prompt_id: std::sync::Arc::new(std::sync::Mutex::new(None)),
         pending_interactions: std::sync::Arc::new(std::sync::Mutex::new(

--- a/crates/codegen/xai-grok-shell/src/session/compaction.rs
+++ b/crates/codegen/xai-grok-shell/src/session/compaction.rs
@@ -3069,6 +3069,9 @@ mod inline_auto_compact_flow_tests {
             delivery_tools: std::cell::RefCell::new(Vec::new()),
             attach_non_interactive: std::cell::Cell::new(false),
             chat_state_handle,
+            prompt_cache: std::sync::Arc::new(parking_lot::Mutex::new(
+                xai_grok_sampling_types::PromptCacheTracker::default(),
+            )),
             current_prompt_id: std::sync::Arc::new(std::sync::Mutex::new(None)),
             pending_interactions: std::sync::Arc::new(std::sync::Mutex::new(
                 std::collections::HashMap::new(),

--- a/crates/codegen/xai-grok-shell/src/session/handle.rs
+++ b/crates/codegen/xai-grok-shell/src/session/handle.rs
@@ -71,6 +71,9 @@ pub struct SessionHandle {
     pub hunk_tracker_handle: HunkTrackerHandle,
     /// Actor-based chat state handle — lets callers inspect final conversation state.
     pub chat_state_handle: xai_chat_state::ChatStateHandle,
+    /// Main-turn prompt-cache tracker shared with the session actor.
+    pub prompt_cache:
+        std::sync::Arc<parking_lot::Mutex<xai_grok_sampling_types::PromptCacheTracker>>,
     /// Handle to session signals (used for completion tracking)
     pub signals_handle: super::signals::SessionSignalsHandle,
     /// Shared gate controlling whether the session actor forwards

--- a/crates/codegen/xai-grok-shell/src/session/slash_commands.rs
+++ b/crates/codegen/xai-grok-shell/src/session/slash_commands.rs
@@ -228,6 +228,14 @@ pub(super) const BUILTIN_COMMANDS: &[BuiltinCommand] = &[
         resolve: |_args| BuiltinAction::SessionInfo,
     },
     BuiltinCommand {
+        name: "cache",
+        description: "Show prompt cache hit rate and where the prefix broke",
+        argument_hint: None,
+        aliases: &[],
+        gate: BuiltinGate::AlwaysOn,
+        resolve: |_args| BuiltinAction::Cache,
+    },
+    BuiltinCommand {
         name: "feedback",
         description: "Send feedback about the current session",
         argument_hint: Some("feedback text"),
@@ -446,6 +454,7 @@ pub const PAGER_COMMAND_KEYS: &[&str] = &[
     "announcements",
     "auto",
     "btw",
+    "cache",
     "cd",
     "changelog",
     "chat",
@@ -920,6 +929,7 @@ pub(super) enum BuiltinAction {
     PluginsReload,
     PluginsTrust,
     SessionInfo,
+    Cache,
     PluginsAdd {
         path: String,
     },
@@ -983,6 +993,7 @@ impl BuiltinAction {
             BuiltinAction::PluginsReload => "plugins-reload",
             BuiltinAction::PluginsTrust => "plugins-trust",
             BuiltinAction::SessionInfo => "session",
+            BuiltinAction::Cache => "cache",
             BuiltinAction::PluginsAdd { .. } => "plugins-add",
             BuiltinAction::PluginsRemove { .. } => "plugins-remove",
             BuiltinAction::PluginsInstall { .. } => "plugins-install",
@@ -1020,6 +1031,7 @@ impl BuiltinAction {
             BuiltinAction::PluginsReload => false,
             BuiltinAction::PluginsTrust => false,
             BuiltinAction::SessionInfo => false,
+            BuiltinAction::Cache => false,
             BuiltinAction::PluginsAdd { .. } => true,
             BuiltinAction::PluginsRemove { .. } => true,
             BuiltinAction::PluginsInstall { .. } => true,
@@ -1624,6 +1636,22 @@ mod tests {
     }
 
     #[test]
+    fn cache_resolves_to_cache_action() {
+        let outcome = resolve(
+            vec![text_block("/cache")],
+            &[],
+            all_gated(),
+            SkillSlashRewrite::default(),
+            &[],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            outcome,
+            SlashCommandOutcome::Builtin(BuiltinAction::Cache)
+        ));
+    }
+
+    #[test]
     fn resolve_parses_skill_with_args() {
         let skills = vec![make_skill("commit", true)];
         let outcome = resolve(
@@ -1891,6 +1919,7 @@ mod tests {
                 "plugins",
                 "reload-plugins",
                 "session-info",
+                "cache",
                 "feedback",
                 "deep-research",
                 "workflow",
@@ -2124,7 +2153,13 @@ mod tests {
             );
         }
         // Always-on commands are still present.
-        for required in ["compact", "always-approve", "context", "session-info"] {
+        for required in [
+            "compact",
+            "always-approve",
+            "context",
+            "session-info",
+            "cache",
+        ] {
             assert!(
                 names.iter().any(|n| n == required),
                 "{required} should be present, got: {names:?}",
@@ -2740,7 +2775,13 @@ mod tests {
                 "{forbidden} must not be advertised under default fail-closed availability, got: {names:?}",
             );
         }
-        for required in ["compact", "always-approve", "context", "session-info"] {
+        for required in [
+            "compact",
+            "always-approve",
+            "context",
+            "session-info",
+            "cache",
+        ] {
             assert!(
                 names.iter().any(|n| n == required),
                 "AlwaysOn {required} must always be advertised, got: {names:?}",

--- a/docs/agents/acp.md
+++ b/docs/agents/acp.md
@@ -144,7 +144,7 @@ Handlers live under `shell/src/extensions/` and are dispatched from `MvpAgent`�
 | Git / worktrees | `x.ai/git/*`, `x.ai/git/worktree/*` | `git.rs`, `worktree.rs` |
 | Search | `x.ai/search/*` | `search.rs` |
 | Terminal / PTY | `x.ai/terminal/*` | `terminal.rs` |
-| Session admin | `x.ai/session/*` (info, list, fork, rename, delete, updates, load_history, repair, …) | `session_admin.rs`, `session_updates.rs`, … |
+| Session admin | `x.ai/session/*` (info, list, fork, rename, delete, updates, load_history, repair, usage, cache, …) | `session_admin.rs`, `session_updates.rs`, `usage.rs`, `cache.rs`, … |
 | History / rewind / compact | `x.ai/prompt_history`, `x.ai/rewind*`, `x.ai/compact_conversation*` | `prompt_history.rs`, `rewind.rs` |
 | Auth | `x.ai/auth/*`, `x.ai/getApiKey`, `x.ai/setApiKey` | `auth.rs` |
 | Hooks / plugins / marketplace | `x.ai/hooks/*`, `x.ai/plugins/*`, `x.ai/marketplace/*` | `hooks.rs`, `plugins.rs`, `marketplace.rs` |

--- a/docs/agents/agent-runtime.md
+++ b/docs/agents/agent-runtime.md
@@ -56,6 +56,7 @@ xai-grok-shell::MvpAgent  (LocalSet, !Send)
    - Outcomes: permission reject can cancel turn; hook deny continues with failure result; followups inject user messages
    - Preflight overflow → compact and continue
    - Honor `max_turns`
+   - On inference usage, `record_and_log_prompt_cache` fingerprints the main-turn request and logs `shell.turn.prompt_cache` (plus `_break` / `_miss`). Auxiliary calls must not record — they would poison the next prefix.
 4. Auth recovery uses **`AuthRetrySchedule` of 1s / 2s / 4s** (do not inflate bases — hang regressions).
 
 ### Invariants

--- a/docs/agents/providers.md
+++ b/docs/agents/providers.md
@@ -194,6 +194,8 @@ Also isolated:
 | Doom-loop opt-in | yes | no | no | no | no | no | no | no |
 | Responses extras | minimal | Max/Ultra mapping, multi-agent mode, reasoning summary | N/A | N/A | stateless fields; effort normalized to none/low/high/max | stateless fields; preserves low/medium/high/xhigh | N/A | N/A |
 | Prompt cache key | no | session id | no | no | no | no | no | no |
+
+Main-turn requests are fingerprinted (model, tools, system, earlier items — hashes only). `/cache` and `x.ai/session/cache` report session hit rate and the first prefix section that changed. Auxiliary calls (recap, `/btw`) log hit rate but must not record on the tracker. Search `shell.turn.prompt_cache_break` / `shell.turn.prompt_cache_miss`.
 | Sticky turn state | no | `x-codex-turn-state` | no | no | no | no | no | no |
 | Unknown `response.*` events | strict | ignore unknown side-channels when opted | N/A | N/A | strict | strict | N/A | N/A |
 | Chat sanitization | — | — | clears temp/top_p/penalties | schema normalization | strips internal message model IDs | N/A | standard | per backend |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a way to **view prompt-cache hit rate** and **see where the KV-cache prefix broke**, so we can debug misses without logging prompt text.

`/cache` (TUI and headless) prints the session report. `/usage` now includes the session hit rate next to input tokens. Main-turn inference logs `shell.turn.prompt_cache`, plus `shell.turn.prompt_cache_break` / `shell.turn.prompt_cache_miss` when the prefix changes or a stable prefix still reports 0% cached tokens.

## How

Provider KV caches are prefix-addressed. Each main-turn request is fingerprinted by ordered sections (model, effort, temperature, cache key, tools, then `item[i]:<kind>`). The tracker diffs consecutive main-turn fingerprints and records the first changed section as hashes + labels only.

Auxiliary calls (recap, `/btw`) log hit rate but **do not** record on the tracker — they would poison the next turn’s prefix.

A 0% hit on a **stable** prefix, with the cache key forwarded and prompt ≥ 1024 tokens, is counted as a provider miss rather than a prefix break.

ACP: `x.ai/session/cache` → `{ report, text }`.

## Verification

- `cargo test --locked -p xai-grok-sampling-types --lib prompt_cache` — 13 passed
- `cargo test --locked -p xai-grok-shell --lib -- cache` — 105 passed (includes `session_cache_*`, `extensions::cache`, `/cache` resolve)
- AlwaysOn slash lists: `available_commands_orders_builtins_first`, `pre_session_builtin_commands_excludes_gated_entries`, `default_availability_is_fail_closed_on_every_gate`
- `cargo test --locked -p xai-grok-pager --lib -- cache status_blocks session_cache show_cache pager_builtin_triggers shell_collision_contract` — 75 passed
- Dashboard hide-list: `hide_session_scoped_filters_session_commands_from_dropdown`, `hide_session_scoped_filters_fuzzy_query`

## Notes

No prompt text is logged. Tracker is process-local (resets on resume in a new agent).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5aafb8e2-35b3-40b9-a76b-fd0f094d93d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5aafb8e2-35b3-40b9-a76b-fd0f094d93d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

